### PR TITLE
Redefine double colon

### DIFF
--- a/src/Prelude.agda
+++ b/src/Prelude.agda
@@ -37,6 +37,3 @@ open import Prelude.IO          public
 
 open import Prelude.Equality.Unsafe  public using (eraseEquality)
 open import Prelude.Equality.Inspect public
-
-infixr 5 _::_
-pattern _::_ x xs = x ∷ xs

--- a/src/Tactic/Reflection.agda
+++ b/src/Tactic/Reflection.agda
@@ -32,6 +32,9 @@ _`→_  a b = pi (vArg a) (abs "_" b)
 _`→ʰ_ a b = pi (hArg a) (abs "_" b)
 _`→ⁱ_ a b = pi (iArg a) (abs "_" b)
 
+_::_ : Term → Type → TC Term
+_::_ = checkType
+
 on-goal : (Type → Tactic) → Tactic
 on-goal tac hole = inferType hole >>= λ goal → tac goal hole
 


### PR DESCRIPTION
I don't think that _::_ belongs in the Prelude. (Unicode-phobes need not apply!) Instead, it works as a good mnemonic for checkType.

```
do ...
   τ ← t :: T -- In memoriam that t is of type T, we say τ!
   ...
```