### PR TITLE
Use the provided type in evalTC

### DIFF
--- a/src/Tactic/Reflection.agda
+++ b/src/Tactic/Reflection.agda
@@ -50,7 +50,12 @@ macro
   runT t = t
 
 evalTC : ∀ {a} {A : Set a} → TC A → Tactic
-evalTC c hole = c >>=′ quoteTC >>= unify hole
+evalTC {A = A} c hole =
+  do v ← c
+  =| `v ← quoteTC v
+  -| `A ← quoteTC A
+  -| checkedHole ← checkType hole `A
+  -| unify checkedHole `v
 
 macro
   evalT : ∀ {a} {A : Set a} → TC A → Tactic


### PR DESCRIPTION
The current version of `evalTC` does not use all the type information. For example given this function:

```
f : Nat → Nat
f = const 3
```

The type of `evalT (return f)` would be inferred as `(z : _z_188) → Nat`.

With this version of `evalTC` the type is correctly inferred as `Nat → Nat`. So evaluating a `TC A` always returns something of type `A` and not something less precise.

I am not 100% sure that i really need to use `checkedHole` instead of `hole` to unify with. I did not find any cases where it made a difference but it felt like the right thing to do.