### PR TITLE
[reflection] [major refactor] [fixes #28] generalise Tactic.Nat to work with other libraries

### DIFF
--- a/src/Tactic/Nat.agda
+++ b/src/Tactic/Nat.agda
@@ -1,127 +1,77 @@
-
-module Tactic.Nat where
+open import Agda.Builtin.Reflection using (Name)
+module Tactic.Nat (`_≤ₐ_ `≤ₐ→≤₀ `≤₀→≤ₐ : Name) where
 
 open import Prelude
-
-open import Tactic.Nat.Reflect public using (cantProve; invalidGoal; QED)
-open import Tactic.Nat.Induction public
-open import Tactic.Nat.Subtract public renaming
-  ( autosub     to auto
-  ; simplifysub to simplify
-  ; refutesub   to refute )
-
--- All tactics know about addition, multiplication and subtraction
--- of natural numbers, and can prove equalities and inequalities (_<_).
--- The available tactics are:
-
-{-
-  auto
-
-    Prove an equation or inequality.
--}
+open import Tactic.Reflection
+open import Tactic.Nat.Induction using (nat-induction)
+open import Tactic.Nat.Subtract using (autosub-tactic; by-tactic; refutesub-tactic; simplifygoal-tactic; simplifysub-tactic)
 
 private
-  auto-example₁ : (a b : Nat) → (a - b) * (a + b) ≡ a ^ 2 - b ^ 2
-  auto-example₁ a b = auto
+  a→0 : Type → Term
+  a→0 (def operator _) = ifYes operator == `_≤ₐ_ then def₀ `≤ₐ→≤₀ else def₀ (quote id)
+  a→0 _ = def₀ (quote id) -- TODO perhaps return unknown?
 
-  auto-example₂ : (a b : Nat) → (a + b) ^ 2 ≥ a ^ 2 + b ^ 2
-  auto-example₂ a b = auto
+  0→a : Type → Term
+  0→a (def operator _) = ifYes operator == `_≤ₐ_ then def₀ `≤₀→≤ₐ else def₀ (quote id)
+  0→a _ = def₀ (quote id) -- TODO perhaps return unknown?
 
-{-
-  by eq
-
-    Prove the goal using the given assumption. For equalities it simplifies
-    the goal and the assumption and checks if they match any of the following
-    forms (up to symmetry):
-
-          a ≡ b → a ≡ b
-      a + b ≡ 0 → a ≡ 0
-
-    For inequalities, to prove a < b -> c < d, it simplifies the assumption and
-    goal and then tries to prove c′ ≤ a′ and b′ ≤ d′.
-
-    When proving that an inequality follows from an equality a ≡ b, the equality
-    is weakened to a ≤ b before applying the above procedure.
-
-    Proving an equality from an inequality works if the inequality simplifies to
-    a ≤ 0 (or a < 0 in which case it's trivial). It then reduces that to a ≡ 0
-    and tries to prove the goal from that.
--}
-
-private
-  by-example₁ : (xs ys : List Nat) → sum (xs ++ ys) ≡ sum ys + sum xs
-  by-example₁ []       ys = auto
-  by-example₁ (x ∷ xs) ys = by (by-example₁ xs ys)
-
-  by-example₂ : (a b c : Nat) → a + c < b + c → a < b
-  by-example₂ a b c lt = by lt
-
-  by-example₃ : (a b : Nat) → a ≡ b * 2 → a + b < (b + 1) * 3
-  by-example₃ a b eq = by eq
-
-  by-example₄ : (a b c : Nat) → a + b + c ≤ b → 2 * c ≡ c
-  by-example₄ a b c lt = by lt
-
-{-
-  refute eq
-
-  Proves an arbitrary proposition given a false equation. Works for equations
-  that simplify to 0 ≡ suc n (or symmetric) or n < 0, for some n.
--}
-
-private
-  refute-example₁ : {Anything : Set} (a : Nat) → a ≡ 2 * a + 1 → Anything
-  refute-example₁ a eq = refute eq
-
-  refute-example₂ : {Anything : Set} (a b : Nat) → a + b < a → Anything
-  refute-example₂ a b lt = refute lt
-
-{-
-  simplify-goal ?
-
-    Simplify the current goal and let you keep working on the new goal.
-    In most cases 'by prf' works better than
-    'simplify-goal => prf' since it will also simplify prf. The advantage
-    of simplify-goal is that it allows holes in prf.
--}
-
-private
-  simplify-goal-example : (a b : Nat) → a - b ≡ b - a → a ≡ b
-  simplify-goal-example  zero    b      eq = by eq
-  simplify-goal-example (suc a)  zero   eq = refute eq
-  simplify-goal-example (suc a) (suc b) eq =
-    simplify-goal (simplify-goal-example a b eq)
-    -- Old goal: suc a ≡ suc b
-    -- New goal:     a ≡ b
-
-{-
-  simplify eq λ x → ?
-
-    Simplify the given equation (and the current goal) and bind the simplified
-    equation to x in the new goal.
--}
-
-private
-  lemma : (a b : Nat) → a + b ≡ 0 → a ≡ 0
-  lemma zero    b eq = refl
-  lemma (suc a) b eq = refute eq
-
-  simplify-example : ∀ a b → (a + 1) * (b + 1) ≡ a * b + 1 → a ≡ 0
-  simplify-example a b eq = simplify eq λ eq′ → lemma a b eq′
-
-{-
-  induction
-
-    Prove a goal ∀ n → P n using induction. Applies 'auto' in the base case
-    and 'by IH' in the step case.
--}
-
-private
-  -- n .. 1
-  downFrom : Nat → List Nat
-  downFrom zero    = []
-  downFrom (suc n) = suc n ∷ downFrom n
-
-  induction-example : ∀ n → sum (downFrom n) * 2 ≡ n * (n + 1)
-  induction-example = induction
-
+macro
+  auto : Tactic
+  auto holeₐ = do
+    goalₐ ← inferType holeₐ -|
+    hole₀ := a→0 goalₐ `$ holeₐ -|
+    (holeₐ =′_) ∘ (0→a goalₐ `$_) =<< autosub-tactic =<< inferType =<< normalise hole₀
+ 
+  by : Term → Tactic
+  by prfₐ holeₐ = do
+    goalₐ ← inferType holeₐ -|
+    hole₀ := a→0 goalₐ `$ holeₐ -|
+    Prfₐ ← inferType prfₐ -|
+    prf₀ := a→0 Prfₐ `$ prfₐ -|
+    (holeₐ =′_) ∘ (0→a goalₐ `$_) =<< by-tactic prf₀ =<< inferType =<< normalise hole₀
+ 
+  refute : Term → Tactic
+  refute prfₐ holeₐ = do
+    Prfₐ ← inferType prfₐ -|
+    prf₀ := a→0 Prfₐ `$ prfₐ -|
+    (holeₐ =′_) =<< refutesub-tactic prf₀
+ 
+  simplify-goal : Tactic
+  simplify-goal holeₐ = do
+    goalₐ ← inferFunRange holeₐ -|
+    s-goal₀ ← simplifygoal-tactic =<< inferFunRange (a→0 goalₐ `∘ holeₐ) -|
+    holeₐ =′ 0→a goalₐ `∘ s-goal₀ `∘ a→0 goalₐ
+ 
+  simplify : Term → Tactic 
+  simplify prfₐ holeₐ =
+    goalₐ ← inferFunRange holeₐ -|
+    Prfₐ ← inferType prfₐ -|
+    prf₀ := a→0 Prfₐ `$ prfₐ -|
+    s-goal₀ ← simplifysub-tactic prf₀ =<< inferFunRange (a→0 goalₐ `∘ holeₐ) -|
+    holeₐ =′ (`λ $ 0→a goalₐ `$ weaken 1 s-goal₀ `$ `λ $ a→0 goalₐ `$ var₁ 1 (0→a Prfₐ `$ var₀ 0))
+ 
+  induction : Tactic
+  induction holeₐ = do
+    goalₐ ← caseM inferType holeₐ of (λ
+    { (pi _ (abs _ t)) → pure t
+    ; (meta x _) → blockOnMeta x
+    ; _ → typeErrorS "Induction tactic must be applied to a function goal"
+    }) -|
+    hole₀ ← (a→0 goalₐ `∘ holeₐ) :′ unknown -|
+    caseM inferType hole₀ of λ
+    { (pi a b)   →
+        let P = lam visible b
+            inStepCxt : {A : Set} → TC A → TC A
+            inStepCxt {_} = λ′ (vArg (quoteTerm Nat)) ∘
+                            λ′ (vArg unknown) in
+        do base ← unknown :′ unknown -|
+           step ← inStepCxt $ unknown :′ unknown -|
+           holeₐ =′ 0→a goalₐ `∘ def₃ (quote nat-induction)
+                                      P
+                                      base
+                                      (`λ $ `λ step) ~|
+           base =′_ =<< autosub-tactic =<< inferType base ~|
+           inStepCxt (step =′_ =<< by-tactic (var₀ 0) =<< inferType step)
+    ; (meta x _) → blockOnMeta x
+    ; _          → typeErrorS "Induction tactic must be applied to a function goal"
+    }

--- a/src/Tactic/Nat/Induction.agda
+++ b/src/Tactic/Nat/Induction.agda
@@ -2,44 +2,7 @@
 module Tactic.Nat.Induction where
 
 open import Prelude
-open import Tactic.Nat.Subtract
-open import Tactic.Nat.Reflect
-open import Builtin.Reflection
-open import Tactic.Reflection.Quote
-open import Tactic.Reflection.DeBruijn
-open import Tactic.Reflection.Substitute
-open import Tactic.Reflection
 
 nat-induction : (P : Nat → Set) → P 0 → (∀ n → P n → P (suc n)) → ∀ n → P n
 nat-induction P base step  zero   = base
 nat-induction P base step (suc n) = step n (nat-induction P base step n)
-
-induction-goal-must-be-a-function-type : ⊤
-induction-goal-must-be-a-function-type = _
-
--- TODO: in library
-private
-  newMeta! : TC Term
-  newMeta! = newMeta unknown
-
-  vlam : Term → Term
-  vlam b = lam visible (abs "_" b)
-
-macro
-  induction : Tactic
-  induction hole =
-    caseM inferType hole of λ
-    { (pi a b)   →
-        let P = lam visible b
-            inStepCxt : {A : Set} → TC A → TC A
-            inStepCxt {_} = extendContext (vArg (quoteTerm Nat)) ∘
-                            extendContext (vArg unknown) in
-        do base ← newMeta!
-        -| step ← inStepCxt newMeta!
-        -| unify hole (def (quote nat-induction)
-                           (vArg P ∷ vArg base ∷ vArg (vlam $ vlam step) ∷ []))
-        ~| unify base =<< autosub-tactic =<< inferType base
-        ~| inStepCxt (unify step =<< by-tactic (var 0 []) =<< inferType step)
-    ; (meta x _) → blockOnMeta x
-    ; _          → typeErrorS "Induction tactic must be applied to a function goal"
-    }

--- a/src/Tactic/Nat/Subtract.agda
+++ b/src/Tactic/Nat/Subtract.agda
@@ -1,41 +1,7 @@
 
 module Tactic.Nat.Subtract where
 
-open import Prelude
-open import Builtin.Reflection
-open import Tactic.Reflection.Quote
-open import Tactic.Reflection
-open import Control.Monad.State
-
-open import Tactic.Nat.Reflect
-open import Tactic.Nat.NF
-open import Tactic.Nat.Exp
-open import Tactic.Nat.Auto
-open import Tactic.Nat.Auto.Lemmas
-open import Tactic.Nat.Simpl.Lemmas
-open import Tactic.Nat.Simpl
-open import Tactic.Nat.Reflect
-
-open import Tactic.Nat.Subtract.Exp
-open import Tactic.Nat.Subtract.Reflect
-open import Tactic.Nat.Subtract.Lemmas
-open import Tactic.Nat.Less.Lemmas
-
--- Tactics --
-
-open import Tactic.Nat.Subtract.Auto public
-open import Tactic.Nat.Subtract.Simplify using (simplify-goal; simplifysub ) public
-open import Tactic.Nat.Subtract.By public
-open import Tactic.Nat.Subtract.Refute public
-
-macro
-  autosub : Tactic
-  autosub hole =
-    inferType hole >>= λ goal → unify hole =<< autosub-tactic goal
-
-  by : Term → Tactic
-  by prf hole =
-    inferType hole >>= λ goal → unify hole =<< by-tactic prf goal
-
-  refutesub : Term → Tactic
-  refutesub prf hole = unify hole =<< refutesub-tactic prf
+open import Tactic.Nat.Subtract.Auto public using (autosub-tactic)
+open import Tactic.Nat.Subtract.Simplify public using (simplifysub-tactic; simplifygoal-tactic)
+open import Tactic.Nat.Subtract.By public using (by-tactic)
+open import Tactic.Nat.Subtract.Refute public using (refutesub-tactic)

--- a/src/Tactic/Nat/Subtract/By.agda
+++ b/src/Tactic/Nat/Subtract/By.agda
@@ -168,12 +168,3 @@ by-tactic prf g =
              ∷ [])) _) (vArg prf ∷ [])
     ; _ → pure $ failedProof (quote invalidGoal) t
     }
-
-private
-  macro
-    by : Term → Tactic
-    by prf hole =
-      inferType hole >>= λ goal → unify hole =<< by-tactic prf goal
-
-  test : (a b c : Nat) → a + b ≡ b + c → 2 + a ≡ 1 + c + 1
-  test a b c eq = by eq

--- a/src/Tactic/Nat/Subtract/Simplify.agda
+++ b/src/Tactic/Nat/Subtract/Simplify.agda
@@ -59,25 +59,20 @@ simplifysub-tactic prf g =
     }
 
 simplifygoal-tactic : Type → TC Term
-simplifygoal-tactic (pi _ (abs _ t)) =
-  case strengthen 1 t of λ
-  { nothing → typeErrorS "simplify-goal must be applied in a non-dependent function position"
-  ; (just t) →
-    caseM termToSubHyps t of λ
-    { nothing → pure $ failedProof (quote invalidGoal) t
-    ; (just (goal , Γ)) → pure $
-        def (quote simplifySubH)
-          $ vArg (` goal)
-          ∷ vArg (quotedEnv Γ)
-          ∷ []
-    }
+simplifygoal-tactic t =
+  caseM termToSubHyps t of λ
+  { nothing → pure $ failedProof (quote invalidGoal) t
+  ; (just (goal , Γ)) → pure $
+      def (quote simplifySubH)
+        $ vArg (` goal)
+        ∷ vArg (quotedEnv Γ)
+        ∷ []
   }
-simplifygoal-tactic _ = typeErrorS "simplify-goal must be applied in a function position"
 
 macro
   simplify-goal : Tactic
   simplify-goal hole =
-    do goal ← forceFun =<< inferType hole
+    do goal ← inferFunType hole
     -| unify hole =<< simplifygoal-tactic goal
 
   simplifysub : Term → Tactic

--- a/src/Tactic/Nat/Subtract/Simplify.agda
+++ b/src/Tactic/Nat/Subtract/Simplify.agda
@@ -24,21 +24,21 @@ open import Tactic.Nat.Less.Lemmas
 simplifySubEqn : ∀ eqn ρ → c⟦ eqn ⟧eqn ρ → ⟦ eqn ⟧eqn ρ
 simplifySubEqn (a :≡ b) = simplifySubEq a b
 simplifySubEqn (a :< b) = simplifySubLess a b
-
+ 
 complicateSubEqn : ∀ eqn ρ → ⟦ eqn ⟧eqn ρ → c⟦ eqn ⟧eqn ρ
 complicateSubEqn (a :≡ b) = complicateSubEq a b
 complicateSubEqn (a :< b) = complicateSubLess a b
-
+ 
 ⟦_⟧sh : List Eqn → Env Var → Set
 ⟦ [] ⟧sh ρ = ⊥
 ⟦ h ∷ [] ⟧sh ρ = ⟦ h ⟧eqn ρ
 ⟦ h ∷ g  ⟧sh ρ = ⟦ h ⟧eqn ρ → ⟦ g ⟧sh ρ
-
+ 
 ⟦_⟧shs : List Eqn → Env Var → Set
 ⟦ [] ⟧shs ρ = ⊥
 ⟦ h ∷ [] ⟧shs ρ = c⟦ h ⟧eqn ρ
 ⟦ h ∷ g  ⟧shs ρ = c⟦ h ⟧eqn ρ → ⟦ g ⟧shs ρ
-
+ 
 simplifySubH : ∀ goal ρ → ⟦ goal ⟧shs ρ → ⟦ goal ⟧sh ρ
 simplifySubH []            ρ ()
 simplifySubH (h ∷ [])     ρ H = simplifySubEqn h ρ H
@@ -68,25 +68,3 @@ simplifygoal-tactic t =
         ∷ vArg (quotedEnv Γ)
         ∷ []
   }
-
-macro
-  simplify-goal : Tactic
-  simplify-goal hole =
-    do goal ← inferFunType hole
-    -| unify hole =<< simplifygoal-tactic goal
-
-  simplifysub : Term → Tactic
-  simplifysub prf hole =
-    caseM forceFun =<< inferType hole of λ
-    { (pi _ (abs _ goal)) →
-      flip (maybe (typeErrorS "Should be non-dependent function")) (strengthen 1 goal) λ goal →
-      unify hole =<< simplifysub-tactic prf goal
-    ; _ → typeErrorS "Invalid goal"
-    }
-
-private
-  test-goal : (a b c : Nat) → a ≡ c → a + b ≡ b + c
-  test-goal a b c eq = simplify-goal eq
-
-  test-simp : (a b c : Nat) → a + b ≡ b + c → 2 + a ≡ 1 + c + 1
-  test-simp a b c eq = simplifysub eq λ eq′ → eq′

--- a/src/Tactic/Reflection.agda
+++ b/src/Tactic/Reflection.agda
@@ -69,8 +69,8 @@ forceFun a =
   -| unify a (dom `→ weaken 1 rng)
   ~| normalise a
 
-inferFunType : Term → TC Type
-inferFunType hole = unPi =<< forceFun =<< inferType hole where
+inferFunRange : Term → TC Type
+inferFunRange hole = unPi =<< forceFun =<< inferType hole where
   unPi : Type → TC Type
   unPi (pi _ (abs _ (meta x _))) = blockOnMeta! x
   unPi (pi _ (abs _ b)) = maybe (typeError (strErr "Must be applied in a non-dependent function position" ∷ termErr b ∷ [])) pure $ strengthen 1 b

--- a/src/Tactic/Reflection.agda
+++ b/src/Tactic/Reflection.agda
@@ -69,6 +69,13 @@ forceFun a =
   -| unify a (dom `→ weaken 1 rng)
   ~| normalise a
 
+inferFunType : Term → TC Type
+inferFunType hole = unPi =<< forceFun =<< inferType hole where
+  unPi : Type → TC Type
+  unPi (pi _ (abs _ (meta x _))) = blockOnMeta! x
+  unPi (pi _ (abs _ b)) = maybe (typeError (strErr "Must be applied in a non-dependent function position" ∷ termErr b ∷ [])) pure $ strengthen 1 b
+  unPi x = typeError (strErr "Invalid goal" ∷ termErr x ∷ [])
+
 macro
   runT : Tactic → Tactic
   runT t = t

--- a/test/NatTactic.agda
+++ b/test/NatTactic.agda
@@ -1,0 +1,244 @@
+module NatTactic where
+
+  module _ where
+    open import Agda.Builtin.Nat
+    open import Agda.Builtin.List
+    
+    -- n .. 1
+    downFrom : Nat → List Nat
+    downFrom zero    = []
+    downFrom (suc n) = suc n ∷ downFrom n
+
+  module AgdaPreludeTest where
+    open import Prelude
+    open import Tactic.Nat (quote _≤_) (quote id) (quote id)
+
+-- All tactics know about addition, multiplication and subtraction
+-- of natural numbers, and can prove equalities and inequalities (_<_).
+-- The available tactics are:
+     
+{-
+  auto
+ 
+    Prove an equation or inequality.
+-}
+
+    auto-example₁ : (a b : Nat) → (a - b) * (a + b) ≡ a ^ 2 - b ^ 2
+    auto-example₁ a b = auto
+   
+    auto-example₂ : (a b : Nat) → (a + b) ^ 2 ≥ a ^ 2 + b ^ 2
+    auto-example₂ a b = auto
+
+{-
+  by eq
+
+    Prove the goal using the given assumption. For equalities it simplifies
+    the goal and the assumption and checks if they match any of the following
+    forms (up to symmetry):
+
+          a ≡ b → a ≡ b
+      a + b ≡ 0 → a ≡ 0
+
+    For inequalities, to prove a < b -> c < d, it simplifies the assumption and
+    goal and then tries to prove c′ ≤ a′ and b′ ≤ d′.
+
+    When proving that an inequality follows from an equality a ≡ b, the equality
+    is weakened to a ≤ b before applying the above procedure.
+
+    Proving an equality from an inequality works if the inequality simplifies to
+    a ≤ 0 (or a < 0 in which case it's trivial). It then reduces that to a ≡ 0
+    and tries to prove the goal from that.
+-}
+
+    by-example₁ : (xs ys : List Nat) → sum (xs ++ ys) ≡ sum ys + sum xs
+    by-example₁ []       ys = auto
+    by-example₁ (x ∷ xs) ys = by (by-example₁ xs ys)
+   
+    by-example₂ : (a b c : Nat) → a + c < b + c → a < b
+    by-example₂ a b c lt = by lt
+   
+    by-example₃ : (a b : Nat) → a ≡ b * 2 → a + b < (b + 1) * 3
+    by-example₃ a b eq = by eq
+   
+    by-example₄ : (a b c : Nat) → a + b + c ≤ b → 2 * c ≡ c
+    by-example₄ a b c lt = by lt
+
+    by-example₅ : (a b c : Nat) → a + b ≡ b + c → 2 + a ≡ 1 + c + 1
+    by-example₅ a b c eq = by eq
+
+{-
+  refute eq
+
+  Proves an arbitrary proposition given a false equation. Works for equations
+  that simplify to 0 ≡ suc n (or symmetric) or n < 0, for some n.
+-}
+
+    refute-example₁ : {Anything : Set} (a : Nat) → a ≡ 2 * a + 1 → Anything
+    refute-example₁ a eq = refute eq
+   
+    refute-example₂ : {Anything : Set} (a b : Nat) → a + b < a → Anything
+    refute-example₂ a b lt = refute lt
+
+{-
+  simplify-goal ?
+
+    Simplify the current goal and let you keep working on the new goal.
+    In most cases 'by prf' works better than
+    'simplify-goal => prf' since it will also simplify prf. The advantage
+    of simplify-goal is that it allows holes in prf.
+-}
+
+    simplify-goal-example₁ : (a b : Nat) → a - b ≡ b - a → a ≡ b
+    simplify-goal-example₁  zero    b      eq = by eq
+    simplify-goal-example₁ (suc a)  zero   eq = refute eq
+    simplify-goal-example₁ (suc a) (suc b) eq =
+      simplify-goal (simplify-goal-example₁ a b eq)
+      -- Old goal: suc a ≡ suc b
+      -- New goal:     a ≡ b
+
+    simplify-goal-example₂ : (a b : Nat) → a - b ≡ b - a → a < suc b
+    simplify-goal-example₂  zero    b      eq = by eq
+    simplify-goal-example₂ (suc a)  zero   eq = refute eq
+    simplify-goal-example₂ (suc a) (suc b) eq =
+      simplify-goal (simplify-goal-example₂ a b eq)
+      -- Old goal: suc a ≤ suc b
+      -- New goal:     a ≤ b
+
+    simplify-goal-example₃ : (a b c : Nat) → a ≡ c → a + b ≡ b + c
+    simplify-goal-example₃ a b c eq = simplify-goal eq
+
+{-
+  simplify eq λ x → ?
+
+    Simplify the given equation (and the current goal) and bind the simplified
+    equation to x in the new goal.
+-}
+
+    lemma₁ : (a b : Nat) → a + b ≡ 0 → a ≡ 0
+    lemma₁ zero    b eq = refl
+    lemma₁ (suc a) b eq = refute eq
+   
+    simplify-example₁ : ∀ a b → (a + 1) * (b + 1) ≡ a * b + 1 → a ≡ 0
+    simplify-example₁ a b eq = simplify eq λ eq′ → lemma₁ a b eq′
+   
+    lemma₂ : (a b : Nat) → a + b ≡ 0 → a < suc 0
+    lemma₂ zero    b eq = auto
+    lemma₂ (suc a) b eq = refute eq
+   
+    simplify-example₂ : ∀ a b → (a + 1) * (b + 1) ≡ a * b + 1 → a < suc 0
+    simplify-example₂ a b eq = simplify eq λ eq′ → by (lemma₂ a b eq′)
+
+    simplify-example₃ : (a b c : Nat) → a + b ≡ b + c → 2 + a ≡ 1 + c + 1
+    simplify-example₃ a b c eq = simplify eq λ eq′ → eq′
+
+{-
+  induction
+
+    Prove a goal ∀ n → P n using induction. Applies 'auto' in the base case
+    and 'by IH' in the step case.
+-}
+
+    induction-example₁ : ∀ n → sum (downFrom n) * 2 ≡ n * (n + 1)
+    induction-example₁ = induction
+
+    induction-example₂ : ∀ n → sum (downFrom n) * 2 < suc (n * (n + 1))
+    induction-example₂ = induction
+
+  -- some equivalences needed to adapt Tactic.Nat to the standard library
+  module EquivalenceOf≤ where
+    open import Agda.Builtin.Equality
+    open import Agda.Builtin.Nat
+    
+    open import Data.Nat using (less-than-or-equal) renaming (_≤_ to _≤ₛ_)
+    open import Data.Nat.Properties using (≤⇒≤″; ≤″⇒≤)
+    open import Prelude using (diff; id) renaming (_≤_ to _≤ₚ_)
+
+    open import Tactic.Nat (quote _≤ₚ_) (quote id) (quote id) using (by)
+
+    ≤ₚ→≤ₛ : ∀ {a b} → a ≤ₚ b → a ≤ₛ b
+    ≤ₚ→≤ₛ (diff k b₊₁≡k₊₁+a) = ≤″⇒≤ (less-than-or-equal {k = k} (by b₊₁≡k₊₁+a))
+   
+    ≤ₛ→≤ₚ : ∀ {a b} → a ≤ₛ b → a ≤ₚ b
+    ≤ₛ→≤ₚ a≤ₛb with ≤⇒≤″ a≤ₛb
+    ≤ₛ→≤ₚ _ | less-than-or-equal {k = k} a+k≡b = diff k (by a+k≡b)
+
+  module StandardLibraryTest where
+    open import Agda.Builtin.Equality
+    open import Data.Nat
+    open import Data.List hiding (downFrom)
+    open import Function
+
+    private
+      infixr 8 _^_
+      _^_ : ℕ → ℕ → ℕ
+      n ^ zero  = 1
+      n ^ suc m = n ^ m * n
+    
+    open EquivalenceOf≤
+    open import Tactic.Nat (quote _≤_) (quote ≤ₛ→≤ₚ) (quote ≤ₚ→≤ₛ)
+
+    auto-example₁ : (a b : ℕ) → (a ∸ b) * (a + b) ≡ a ^ 2 ∸ b ^ 2
+    auto-example₁ a b = auto
+   
+    auto-example₂ : (a b : ℕ) → (a + b) ^ 2 ≥ a ^ 2 + b ^ 2
+    auto-example₂ a b = auto
+
+    by-example₁ : (xs ys : List ℕ) → sum (xs ++ ys) ≡ sum ys + sum xs
+    by-example₁ []       ys = auto
+    by-example₁ (x ∷ xs) ys = by (by-example₁ xs ys)
+   
+    by-example₂ : (a b c : ℕ) → a + c < b + c → a < b
+    by-example₂ a b c lt = by lt
+   
+    by-example₃ : (a b : ℕ) → a ≡ b * 2 → a + b < (b + 1) * 3
+    by-example₃ a b eq = by eq
+   
+    by-example₄ : (a b c : ℕ) → a + b + c ≤ b → 2 * c ≡ c
+    by-example₄ a b c lt = by lt
+
+    by-example₅ : (a b c : ℕ) → a + b ≡ b + c → 2 + a ≡ 1 + c + 1
+    by-example₅ a b c eq = by eq
+
+    refute-example₁ : {Anything : Set} (a : ℕ) → a ≡ 2 * a + 1 → Anything
+    refute-example₁ a eq = refute eq
+   
+    refute-example₂ : {Anything : Set} (a b : ℕ) → a + b < a → Anything
+    refute-example₂ a b lt = refute lt
+
+    simplify-goal-example₁ : (a b : ℕ) → a ∸ b ≡ b ∸ a → a ≡ b
+    simplify-goal-example₁  zero    b      eq = by eq
+    simplify-goal-example₁ (suc a)  zero   eq = refute eq
+    simplify-goal-example₁ (suc a) (suc b) eq =
+      simplify-goal (simplify-goal-example₁ a b eq)
+
+    simplify-goal-example₂ : (a b : ℕ) → a ∸ b ≡ b ∸ a → a < suc b
+    simplify-goal-example₂  zero    b      eq = by eq
+    simplify-goal-example₂ (suc a)  zero   eq = refute eq
+    simplify-goal-example₂ (suc a) (suc b) eq =
+      simplify-goal (by (simplify-goal-example₂ a b eq))
+
+    simplify-goal-example₃ : (a b c : ℕ) → a ≡ c → a + b ≡ b + c
+    simplify-goal-example₃ a b c eq = simplify-goal eq
+
+    lemma₁ : (a b : ℕ) → a + b ≡ 0 → a ≡ 0
+    lemma₁ zero    b eq = refl
+    lemma₁ (suc a) b eq = refute eq
+   
+    simplify-example₁ : ∀ a b → (a + 1) * (b + 1) ≡ a * b + 1 → a ≡ 0
+    simplify-example₁ a b eq = simplify eq λ eq′ → lemma₁ a b eq′
+   
+    lemma₂ : (a b : ℕ) → a + b ≡ 0 → a < suc 0
+    lemma₂ zero    b eq = s≤s z≤n
+    lemma₂ (suc a) b eq = refute eq
+   
+    simplify-example₂ : ∀ a b → (a + 1) * (b + 1) ≡ a * b + 1 → a < suc 0
+    simplify-example₂ a b eq = simplify eq λ eq′ → by (lemma₂ a b eq′)
+
+    simplify-example₃ : (a b c : ℕ) → a + b ≡ b + c → 2 + a ≡ 1 + c + 1
+    simplify-example₃ a b c eq = simplify eq λ eq′ → eq′
+    
+    induction-example₁ : ∀ n → sum (downFrom n) * 2 ≡ n * (n + 1)
+    induction-example₁ = induction
+
+    induction-example₂ : ∀ n → sum (downFrom n) * 2 < suc (n * (n + 1))
+    induction-example₂ = induction

--- a/test/test.agda-lib
+++ b/test/test.agda-lib
@@ -1,3 +1,4 @@
 name: prelude-test
 include: .
          ../src
+depend: standard-library


### PR DESCRIPTION
Fixes issue #28.

* simplifygoal-tactic now needs only the target of simplification
* we use inferFunRange to feed the desired target to simplifygoal-tactic.
* add module parameters to Tactic.Nat for ≤ and conversions between agda-prelude's ≤ and that of your library of choice
* moved all tests of Tactic.Nat (and subsidiaries) to tests/NatTactic.agda
* add dependency of standard-library to test/test.agda-lib (for tests of Tactic.Nat)

NB: this depends on pull https://github.com/UlfNorell/agda-prelude/pull/30