### PR TITLE
[reright] Refactoring and fix for #23

### DIFF
--- a/src/Tactic/Reflection/Reright.agda
+++ b/src/Tactic/Reflection/Reright.agda
@@ -180,45 +180,15 @@ module Tactic.Reflection.Reright where
           iʷs ← make-vars-from-args [iʷ∣γᶜᵢ∈Γʳ] γʷs -|
           pure $ var 0 (reverse (weaken 1 iʷs))
 
-      extendHelper : ∀ {a} {A : Set a} → TC A → TC A
-      extendHelper =
-        maybe (const $ typeError ( strErr "error constructing helper extension" ∷
-                                   strErr "\nhelper-type:" ∷ termErr (` helper-type) ∷
-                                   strErr "\ngʳ:" ∷ termErr (` gʳ) ∷
-                                   strErr "\nΓʷ:" ∷ termErr (` Γʷ) ∷
-                                   strErr "\n𝐺ʷ:" ∷ termErr (` 𝐺ʷ) ∷
-                                   strErr "\nl≡r:" ∷ termErr (` l≡r) ∷
-                                   strErr "\nA:" ∷ termErr (` A) ∷
-                                   strErr "\nL:" ∷ termErr (` L) ∷
-                                   strErr "\nR:" ∷ termErr (` R) ∷
-                                   strErr "\nΓᶜ:" ∷ termErr (` Γᶜ) ∷
-                                   strErr "\n𝐺:" ∷ termErr (` 𝐺) ∷
-                                   strErr "\nΓʷ/ᴬ" ∷ termErr (` Γʷ/ᴬ) ∷
-                                   strErr "\nΓʷ/⁻ᴬ" ∷ termErr (` Γʷ/⁻ᴬ) ∷
-                                   strErr "\n[iᶜ∣iᶜ∉FVᴬ]" ∷ termErr (` [iᶜ∣iᶜ∉FVᴬ]) ∷
-                                   strErr "\n[iʷ]" ∷ termErr (` [iʷ]) ∷
-                                   [] ))
-              (λ x → (extendContext (vArg x)))
-              $ helper-extension
-        where
-
-        helper-extension : Maybe Type
-        helper-extension = reorderVars [iʷ]-reverse <$> gʳ where
-          [iʷ]-reverse : List Nat
-          [iʷ]-reverse = for p ← (from 0 for (length [iʷ] + 1)) do maybe 9999 id (find 0 p [iʷ]) where
-            find : Nat → Nat → List Nat → Maybe Nat
-            find m x [] = nothing
-            find m x (l ∷ ls) = ifYes x == l then just m else find (suc m) x ls
-
       callHelper : Name → Tactic
       callHelper n hole =
         maybe (typeError [ strErr "error constructing helper call" ])
-              (unify (weaken 1 hole) ∘ lam visible ∘ abs "_")
+              (unify hole)
               $ helper-call n
         where
         
         helper-call : Name → Maybe Term
-        helper-call n = def n <$> (reverse <$> (_∷_ <$> pure (vArg (var₀ 0)) <*> weaken 2 (_∷_ <$> pure (vArg l≡r) <*> Γʰ))) where
+        helper-call n = def n <$> (reverse <$> (_∷_ <$> pure (vArg l≡r) <*> Γʰ)) where
           Γʰ : Maybe $ List $ Arg Term
           Γʰ = (λ xs → take (length [iᶜ∣iᶜ∉FVᴬ]) xs ++ hArg unknown ∷ drop (length [iᶜ∣iᶜ∉FVᴬ]) xs) <$> (join $ make-vars-from-args <$> pure ([iᶜ∣iᶜ∉FVᴬ] ++ [iᶜ∣iᶜ∈FVᴬ]) <*> Γʰ') where
             Γʰ' : Maybe (List (Arg Type))
@@ -247,6 +217,5 @@ module Tactic.Reflection.Reright where
       q ← getRequest l≡r hole -|
       n ← freshName "reright" -|
       let open Request q in 
-      extendHelper $ 
-        defineHelper n ~|
-        callHelper n hole
+      defineHelper n ~|
+      callHelper n hole

--- a/src/Tactic/Reflection/Reright.agda
+++ b/src/Tactic/Reflection/Reright.agda
@@ -109,16 +109,16 @@ module Tactic.Reflection.Reright where
 
       module _ where
         private
-          {-# TERMINATING #-}
           Γʷ/ᶜ : Maybe (List (Arg Type))
-          Γʷ/ᶜ = go 0 Γᶜ where
-            go : Nat → List (Arg Type) → Maybe (List (Arg Type))
+          Γʷ/ᶜ = go [iʷ] Γᶜ where
+            go : List Nat → List (Arg Type) → Maybe (List (Arg Type))
             go _ [] = just []
-            go m (γᶜᵢ ∷ Γᶜ) = _∷_ <$> (strengthen 1 $ reorderVars [iʷ] <$> (weaken 1 γᶜᵢ)) <*> (join $ strengthen 1 $ go (suc m) $ weaken 1 Γᶜ)
-
+            go [] _ = nothing
+            go (iʷ ∷ [iʷ]) (γᶜᵢ ∷ Γᶜ) = _∷_ <$> (strengthen (suc iʷ) $ reorderVars [iʷ] <$> γᶜᵢ) <*> (go [iʷ] Γᶜ)
+            
         Γʷ/ᴬ = join $ subsetList <$> Γʷ/ᶜ <*> pure [iᶜ∣iᶜ∈FVᴬ]
         Γʷ/⁻ᴬ = join $ subsetList <$> Γʷ/ᶜ <*> pure [iᶜ∣iᶜ∉FVᴬ]
-        
+
       module _ where
         private
           Lʷ = reorderVars [iʷ] L

--- a/src/Tactic/Reflection/Reright.agda
+++ b/src/Tactic/Reflection/Reright.agda
@@ -6,6 +6,7 @@ module Tactic.Reflection.Reright where
   open import Tactic.Reflection
   open import Tactic.Reflection.Match
   open import Tactic.Reflection.Replace
+  open import Tactic.Reflection.Quote
 
   private
     {-# TERMINATING #-}
@@ -122,11 +123,50 @@ module Tactic.Reflection.Reright where
       
       defineHelper : Name → TC ⊤
       defineHelper n =
-        maybe (typeError [ strErr "error constructing helper function type, patterns, or term" ]) 
+        maybe (typeError ( strErr "error constructing helper function type, patterns, or term" ∷
+                           strErr "\nhelper-type:" ∷ termErr (maybe unknown id helper-type) ∷
+                           strErr "\n`helper-type:" ∷ termErr (` helper-type) ∷
+                           strErr "\nhelper-patterns:" ∷ termErr (` helper-patterns) ∷
+                           strErr "\nhelper-term:" ∷ termErr (maybe unknown id helper-term) ∷
+                           strErr "\ngʳ:" ∷ termErr (` gʳ) ∷
+                           strErr "\nΓʷ:" ∷ termErr (` Γʷ) ∷
+                           strErr "\n𝐺ʷ:" ∷ termErr (` 𝐺ʷ) ∷
+                           strErr "\nl≡r:" ∷ termErr (` l≡r) ∷
+                           strErr "\nA:" ∷ termErr (` A) ∷
+                           strErr "\nL:" ∷ termErr (` L) ∷
+                           strErr "\nR:" ∷ termErr (` R) ∷
+                           strErr "\nΓᶜ:" ∷ termErr (` Γᶜ) ∷
+                           strErr "\n𝐺:" ∷ termErr (` 𝐺) ∷
+                           strErr "\nΓʷ/ᴬ" ∷ termErr (` Γʷ/ᴬ) ∷
+                           strErr "\nΓʷ/⁻ᴬ" ∷ termErr (` Γʷ/⁻ᴬ) ∷
+                           strErr "\n[iᶜ∣iᶜ∈FVᴬ]" ∷ termErr (` [iᶜ∣iᶜ∈FVᴬ]) ∷
+                           strErr "\n[iᶜ∣iᶜ∉FVᴬ]" ∷ termErr (` [iᶜ∣iᶜ∉FVᴬ]) ∷
+                           strErr "\n[iʷ]" ∷ termErr (` [iʷ]) ∷
+                           [] )) 
               (λ {(helper-type , helper-patterns , helper-term) →
                 catchTC
                   (define (vArg n) helper-type [ clause helper-patterns helper-term ])
-                  (typeError ( strErr "error defining helper function" ∷ [] ))
+                  (typeError ( strErr "error defining helper function" ∷
+                               strErr "\nhelper-type:" ∷ termErr helper-type ∷
+                               strErr "\n`helper-type:" ∷ termErr (` helper-type) ∷
+                               strErr "\nhelper-patterns:" ∷ termErr (` helper-patterns) ∷
+                               strErr "\nhelper-term:" ∷ termErr helper-term ∷
+                               strErr "\n`helper-term:" ∷ termErr (` helper-term) ∷
+                               strErr "\ngʳ:" ∷ termErr (` gʳ) ∷
+                               strErr "\nΓʷ:" ∷ termErr (` Γʷ) ∷
+                               strErr "\n𝐺ʷ:" ∷ termErr (` 𝐺ʷ) ∷
+                               strErr "\nl≡r:" ∷ termErr (` l≡r) ∷
+                               strErr "\nA:" ∷ termErr (` A) ∷
+                               strErr "\nL:" ∷ termErr (` L) ∷
+                               strErr "\nR:" ∷ termErr (` R) ∷
+                               strErr "\nΓᶜ:" ∷ termErr (` Γᶜ) ∷
+                               strErr "\n𝐺:" ∷ termErr (` 𝐺) ∷
+                               strErr "\nΓʷ/ᴬ" ∷ termErr (` Γʷ/ᴬ) ∷
+                               strErr "\nΓʷ/⁻ᴬ" ∷ termErr (` Γʷ/⁻ᴬ) ∷
+                               strErr "\n[iᶜ∣iᶜ∈FVᴬ]" ∷ termErr (` [iᶜ∣iᶜ∈FVᴬ]) ∷
+                               strErr "\n[iᶜ∣iᶜ∉FVᴬ]" ∷ termErr (` [iᶜ∣iᶜ∉FVᴬ]) ∷
+                               strErr "\n[iʷ]" ∷ termErr (` [iʷ]) ∷
+                               [] ))
                   })
               (_,_ <$> helper-type <*> (_,_ <$> helper-patterns <*> helper-term))
         where
@@ -142,7 +182,22 @@ module Tactic.Reflection.Reright where
 
       extendHelper : ∀ {a} {A : Set a} → TC A → TC A
       extendHelper =
-        maybe (const $ typeError [ strErr "error constructing helper extension" ])
+        maybe (const $ typeError ( strErr "error constructing helper extension" ∷
+                                   strErr "\nhelper-type:" ∷ termErr (` helper-type) ∷
+                                   strErr "\ngʳ:" ∷ termErr (` gʳ) ∷
+                                   strErr "\nΓʷ:" ∷ termErr (` Γʷ) ∷
+                                   strErr "\n𝐺ʷ:" ∷ termErr (` 𝐺ʷ) ∷
+                                   strErr "\nl≡r:" ∷ termErr (` l≡r) ∷
+                                   strErr "\nA:" ∷ termErr (` A) ∷
+                                   strErr "\nL:" ∷ termErr (` L) ∷
+                                   strErr "\nR:" ∷ termErr (` R) ∷
+                                   strErr "\nΓᶜ:" ∷ termErr (` Γᶜ) ∷
+                                   strErr "\n𝐺:" ∷ termErr (` 𝐺) ∷
+                                   strErr "\nΓʷ/ᴬ" ∷ termErr (` Γʷ/ᴬ) ∷
+                                   strErr "\nΓʷ/⁻ᴬ" ∷ termErr (` Γʷ/⁻ᴬ) ∷
+                                   strErr "\n[iᶜ∣iᶜ∉FVᴬ]" ∷ termErr (` [iᶜ∣iᶜ∉FVᴬ]) ∷
+                                   strErr "\n[iʷ]" ∷ termErr (` [iʷ]) ∷
+                                   [] ))
               (λ x → (extendContext (vArg x)))
               $ helper-extension
         where

--- a/test/Reright.agda
+++ b/test/Reright.agda
@@ -1,10 +1,25 @@
 module Reright where
   open import Prelude
   open import Tactic.Reflection.Reright
+  open import Agda.Builtin.Reflection -- for better pretty-printing of error messages
 
   -- 'reright' presents the user with changed context variabes, to mimic that done by 'rewrite'.
-  simple-reright-test : (A B : Set) (F : Set → Set) → F A → A ≡ B → B → A
-  simple-reright-test A B F FA A≡B b = reright A≡B $ λ (FB : F B) → b
+  simple-reright-test₁ : (A B : Set) (F : Set → Set) → F A → A ≡ B → B → A
+  simple-reright-test₁ A B F FA A≡B b = reright A≡B $ λ (FB : F B) → b
+
+  -- the target of the reright (in this case x≡y₁) is excluded from the changed context variables
+  simple-reright-test₂ : {a : Level} {A : Set a} {x y : A} (x≡y₁ : x ≡ y) (x≡y₂ : x ≡ y) → y ≡ x
+  simple-reright-test₂ {y = y} x≡y₁ x≡y₂ = reright x≡y₁ λ (x≡y₂' : y ≡ y) → refl
+
+  -- the visibility of context variables remains the same in their changed state
+  simple-reright-test₃ : {a : Level} {A : Set a} {x y : A} (x≡y₁ : x ≡ y) (x≡y₂ : x ≡ y) {x≡y₃ : x ≡ y} → y ≡ x
+  simple-reright-test₃ {y = y} x≡y₁ x≡y₂ {x≡y₃} = reright x≡y₁ λ (x≡y₂' : y ≡ y) {x≡y₃' : y ≡ y} → refl
+
+  -- for some reason, when the first changed variable is hidden, it's impossible to bring it into scope
+  {- FAILS - results in unsolved metas
+    problematic-visibility : {a : Level} {A : Set a} {x y : A} (x≡y₁ : x ≡ y) {x≡y₃ : x ≡ y} → y ≡ x
+    problematic-visibility {y = y} x≡y₁ {x≡y₃} = reright x≡y₁ λ {x≡y₃' : y ≡ y} → refl
+  -}
 
   module Test₁ where
     postulate
@@ -122,7 +137,7 @@ module Reright where
              → A₂ a₀² a₁a₀²-1 ≡ A₂ a₀² a₁a₀²-3
     test₁₉ {a₀¹} {a₀²} {a₁a₀²-1} {a₁a₀²-2} {a₁a₀²-3} {a₁a₀²-2=a₁a₀²-3} R X = reright (R a₀¹) {!!}
 
-    {- FAILS
+    {- FAILS (correctly, though perhaps without the most comprehensible of error messages)
       test₂₀' : (f₁ : A₀) (f₂ : A₀) (A₀f₁≡A₀f₂ : A₁ f₁ ≡ A₁ f₂) (g₁ : A₁ f₁) → A₂ f₁ g₁
       test₂₀' f₁ f₂ A₀f₁≡A₀f₂ g₁ rewrite A₀f₁≡A₀f₂ = {!!}
 
@@ -130,6 +145,15 @@ module Reright where
       test₂₀ f₁ f₂ A₀f₁≡A₀f₂ g₁ = reright A₀f₁≡A₀f₂ {!!}
     -}
    
+    test₂₀ : ∀ {a b : Level} {A : Set a} {x y : A} (x≡y : x ≡ y) → Set
+    test₂₀ x≡y = reright x≡y {!!}
+
+    test₂₁ : ∀ {a b : Level} {A : Set a} {x y : A} (B : Set b) (x≡y : x ≡ y) → Set
+    test₂₁ B x≡y = reright x≡y {!!}
+
+    test₂₂ : ∀ {a : Level} {A : Set a} {B : Set} {x : B} {y : B} (x≡y : x ≡ y) → Set
+    test₂₂ x≡y = reright x≡y {!!}
+
   module Test₂ where
     record Map 
              {K : Set}
@@ -167,3 +191,36 @@ module Reright where
       → (k∈putkv∅ : k ∈ (fst $ put {k₀ = k} v {m₁ = ∅} ∅-is-empty))
       → Set
     test₁ v k k∈putkv∅ = let p = (put {k₀ = k} v {m₁ = ∅} ∅-is-empty) in let r = sym (snd $ snd p) in reright r {!!}
+
+{- expected.out
+?0 : b₀² ≡ b₀² → Set
+?1 : (b : B₀) → b ≡ b
+?2 : B₀ → B₀
+?3 : B₀ → B₀
+?4 : Y ≡ Y
+?5 : A₂ 𝑨₀² a₁𝑨₀²
+?6 : (a₁ : A₁ a₀²) → a₀² ≡ a₀² → F (A₂ a₀² a₁) → F (A₁ a₀²) ≡ A₂ a₀² a₁
+?7 : A₂ a₀ a₁a₀²
+?8 : F (A₁ a₀²) → F (A₁ a₀²) ≡ F (F (A₁ a₀²))
+?9 : F (A₁ a₀²) → F (A₁ a₀²) ≡ F (F (A₁ a₀²))
+?10 : C lzero (χ ⊔ β) (A₁ a₀²) →
+Nat →
+Σ Level
+(λ γ → C lzero (χ ⊔ β) (A₁ a₀²) ≡ C γ (χ ⊔ β) (C lzero γ (A₁ a₀¹)))
+?11 : F (A₁ a₀)
+?12 : F (F (F (F (A₁ a₀))))
+?13 : C lzero (l a₀¹ β) (A₁ a₀²) →
+Σ Level
+(λ γ →
+   C lzero (l a₀¹ β) (A₁ a₀²) ≡ C γ (l a₀¹ β) (C lzero γ (A₁ a₀¹)))
+?14 : K₀ a₀² → Set
+?15 : K₀ a₀² → F (K₀ a₀²) → F (F (K₀ a₀²)) ≡ F (K₀ a₀²)
+?16 : (A₀ → A₂ a₀² a₁a₀²-2 ≡ A₂ a₀² a₁a₀²-2) →
+A₂ a₀² a₁a₀²-2 ≡ A₂ a₀² a₁a₀²-3
+?17 : Set
+?18 : Set
+?19 : Set
+?20 : (k ∉ fst (put (get (fst (snd (put v ∅-is-empty)))) ∅-is-empty) →
+ ⊥) →
+Set
+-}

--- a/test/Reright.agda
+++ b/test/Reright.agda
@@ -154,6 +154,18 @@ module Reright where
     test₂₂ : ∀ {a : Level} {A : Set a} {B : Set} {x : B} {y : B} (x≡y : x ≡ y) → Set
     test₂₂ x≡y = reright x≡y {!!}
 
+    {- FAILS (due to agda issue #1890)
+      module _ (l : Level) where
+        postulate P : Set
+     
+        test₂₃ : (p : P)
+                 (A : Set)
+                 (x y : A)
+                 (x≡y : x ≡ y)
+                 → Set
+        test₂₃ _ _ _ _ x≡y = reright x≡y ?
+    -}
+
   module Test₂ where
     record Map 
              {K : Set}


### PR DESCRIPTION
Fixes #23. Also some refactoring. Main points:

* the tricky art of reordering DeBruijn-indexed variables was not being done correctly; this fixes that (I hope!)
* simplify `reright` routine by removing `extendHelper`, which turns out to have been unnecessary.
* added a failing case to test/Reright.agda, which I believe is due to agda/agda#1890.