### PR TITLE
Updates to function composition

### DIFF
--- a/src/Prelude/Function.agda
+++ b/src/Prelude/Function.agda
@@ -23,6 +23,12 @@ _∘_ : ∀ {a b c} {A : Set a} {B : A → Set b} {C : ∀ x → B x → Set c}
 (f ∘ g) x = f (g x)
 {-# INLINE _∘_ #-}
 
+infixr 9 _∘′_
+_∘′_ : ∀ {a b c} {A : Set a} {B : Set b} {C : Set c} →
+         (B → C) → (A → B) → (A → C)
+f ∘′ g = f ∘ g
+{-# INLINE _∘′_ #-}
+
 infixr 0 _$_ _$′_ case_of_ case_return_of_
 _$_ : ∀ {a b} {A : Set a} {B : A → Set b} → (∀ x → B x) → ∀ x → B x
 f $ x = f x

--- a/src/Prelude/Function.agda
+++ b/src/Prelude/Function.agda
@@ -16,7 +16,7 @@ flip : ∀ {a b c} {A : Set a} {B : Set b} {C : A → B → Set c} → (∀ x y 
 flip f x y = f y x
 {-# INLINE flip #-}
 
-infixl 9 _∘_
+infixr 9 _∘_
 _∘_ : ∀ {a b c} {A : Set a} {B : A → Set b} {C : ∀ x → B x → Set c}
         (f : ∀ {x} (y : B x) → C x y) (g : ∀ x → B x) →
         ∀ x → C x (g x)


### PR DESCRIPTION
* change _∘_ from infixl to infixr (The standard-library and Haskell both use right-associativity.)
* add _∘′_ (Stolen from the standard-library. Comes in handy in cases where metavariables would otherwise be unsolved.)