### PR TITLE
Add some IO operations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,9 @@ test/hello
 test/Main
 test/PrimeTest
 test/PrimeTest_p
+test/Files
+test/test_files_bin.out
+test/test_files_txt.out
 *.prof
 *.treeless
 *.hi

--- a/src/Prelude/IO.agda
+++ b/src/Prelude/IO.agda
@@ -60,20 +60,6 @@ postulate
 print : ∀ {a} {A : Set a} {{ShowA : Show A}} → A → IO Unit
 print = putStrLn ∘ show
 
---- File IO ---
-
-FilePath = String
-
-postulate
-  readFile  : FilePath → IO String
-  writeFile : FilePath → String → IO Unit
-
-{-# COMPILED readFile  Data.Text.IO.readFile  . Data.Text.unpack #-}
-{-# COMPILED writeFile Data.Text.IO.writeFile . Data.Text.unpack #-}
-
-{-# COMPILED_UHC readFile  (UHC.Agda.Builtins.primReadFile) #-}
-{-# COMPILED_UHC writeFile (UHC.Agda.Builtins.primWriteFile) #-}
-
 --- Command line arguments ---
 
 {-# IMPORT System.Environment #-}

--- a/src/System/Directory.agda
+++ b/src/System/Directory.agda
@@ -28,11 +28,11 @@ abstract
   listContents' : ∀ {k} → Path k Dir → IO (List (BarePath k))
   listContents' p = fmap (mkBarePath ∘ ((toString p <> "/") <>_)) <$> Internal.listContents (toString p)
 
-  stat : ∀ {k} → BarePath k → IO (T-Path k)
-  stat p = caseF Internal.doesFileExist (BarePath.path p) of (λ
+  resolve : ∀ {k} → BarePath k → IO (T-Path k)
+  resolve p = caseF Internal.doesFileExist (BarePath.path p) of (λ
     { false → Dir , (unsafeFromString (BarePath.path p))
     ; true → File , (unsafeFromString (BarePath.path p)) })
 
 
   listContents : ∀ {k} → Path k Dir → IO (List (T-Path k))
-  listContents p = listContents' p >>= traverse stat
+  listContents p = listContents' p >>= traverse resolve

--- a/src/System/Directory.agda
+++ b/src/System/Directory.agda
@@ -1,0 +1,38 @@
+module System.Directory where
+
+open import System.FilePath
+open import Prelude
+open import Container.Traversable
+
+{-# IMPORT System.Directory #-}
+
+
+private
+  module Internal where
+    postulate
+      listContents : String → IO (List String)
+      doesFileExist : String → IO Bool
+    {-# COMPILED listContents System.Directory.getDirectoryContents #-}
+    {-# COMPILED doesFileExist System.Directory.doesFileExist #-}
+
+
+-- A path not indexed by target.
+T-Path : (k : Kind) → Set
+T-Path k = Σ Target (Path k)
+
+abstract
+  record BarePath (k : Kind) : Set where
+    constructor mkBarePath
+    field path : String
+
+  listContents' : ∀ {k} → Path k Dir → IO (List (BarePath k))
+  listContents' p = fmap (mkBarePath ∘ ((toString p <> "/") <>_)) <$> Internal.listContents (toString p)
+
+  stat : ∀ {k} → BarePath k → IO (T-Path k)
+  stat p = caseF Internal.doesFileExist (BarePath.path p) of (λ
+    { false → Dir , (unsafeFromString (BarePath.path p))
+    ; true → File , (unsafeFromString (BarePath.path p)) })
+
+
+  listContents : ∀ {k} → Path k Dir → IO (List (T-Path k))
+  listContents p = listContents' p >>= traverse stat

--- a/src/System/Directory.agda
+++ b/src/System/Directory.agda
@@ -16,23 +16,7 @@ private
     {-# COMPILED doesFileExist System.Directory.doesFileExist #-}
 
 
--- A path not indexed by target.
-T-Path : (k : Kind) → Set
-T-Path k = Σ Target (Path k)
-
 abstract
-  record BarePath (k : Kind) : Set where
-    constructor mkBarePath
-    field path : String
 
-  listContents' : ∀ {k} → Path k Dir → IO (List (BarePath k))
-  listContents' p = fmap (mkBarePath ∘ ((toString p <> "/") <>_)) <$> Internal.listContents (toString p)
-
-  resolve : ∀ {k} → BarePath k → IO (T-Path k)
-  resolve p = caseF Internal.doesFileExist (BarePath.path p) of (λ
-    { false → Dir , (unsafeFromString (BarePath.path p))
-    ; true → File , (unsafeFromString (BarePath.path p)) })
-
-
-  listContents : ∀ {k} → Path k Dir → IO (List (T-Path k))
-  listContents p = listContents' p >>= traverse resolve
+  listContents : ∀ {k} → Path k → IO (List (Path k))
+  listContents p = fmap (p //_ ∘ relative) <$> Internal.listContents (toString p)

--- a/src/System/FilePath.agda
+++ b/src/System/FilePath.agda
@@ -42,3 +42,6 @@ abstract
 
   relativeFile : String → Path Rel File
   relativeFile = mkPath
+
+  unsafeFromString : ∀ {k t} → String → Path k t
+  unsafeFromString  = mkPath

--- a/src/System/FilePath.agda
+++ b/src/System/FilePath.agda
@@ -1,0 +1,44 @@
+module System.FilePath where
+
+open import Prelude.String
+  
+data Kind : Set where
+  Rel : Kind
+  Abs : Kind
+
+data Target : Set where
+  File : Target
+  Dir : Target
+
+
+abstract
+  record Path (kind : Kind) (target : Target) : Set where
+    constructor mkPath
+    field
+      path : String
+
+  open import Prelude.Monoid
+  open Path
+
+  _/_ : ∀ {k t} → Path k Dir → Path Rel t → Path k t
+  x / y = mkPath (path x <> "/" <> path y)
+
+  _∙_ : ∀ {k} → Path k File → String → Path k File
+  p ∙ ext = mkPath (path p <> "." <> ext)
+
+
+  toString : ∀ {a b} → Path a b → String
+  toString p = path p
+
+
+  absoluteDir : String → Path Abs Dir
+  absoluteDir = mkPath
+
+  relativeDir : String → Path Rel Dir
+  relativeDir = mkPath
+
+  absoluteFile : String → Path Abs File
+  absoluteFile = mkPath
+
+  relativeFile : String → Path Rel File
+  relativeFile = mkPath

--- a/src/System/FilePath.agda
+++ b/src/System/FilePath.agda
@@ -6,13 +6,8 @@ data Kind : Set where
   Rel : Kind
   Abs : Kind
 
-data Target : Set where
-  File : Target
-  Dir : Target
-
-
 abstract
-  record Path (kind : Kind) (target : Target) : Set where
+  record Path (kind : Kind) : Set where
     constructor mkPath
     field
       path : String
@@ -20,28 +15,17 @@ abstract
   open import Prelude.Monoid
   open Path
 
-  _/_ : ∀ {k t} → Path k Dir → Path Rel t → Path k t
-  x / y = mkPath (path x <> "/" <> path y)
+  _//_ : ∀ {k} → Path k → Path Rel → Path k
+  x // y = mkPath (path x <> "/" <> path y)
 
-  _∙_ : ∀ {k} → Path k File → String → Path k File
+  _∙_ : ∀ {k} → Path k → String → Path k
   p ∙ ext = mkPath (path p <> "." <> ext)
 
-
-  toString : ∀ {a b} → Path a b → String
+  toString : ∀ {k} → Path k → String
   toString p = path p
 
+  relative : String → Path Rel
+  relative = mkPath
 
-  absoluteDir : String → Path Abs Dir
-  absoluteDir = mkPath
-
-  relativeDir : String → Path Rel Dir
-  relativeDir = mkPath
-
-  absoluteFile : String → Path Abs File
-  absoluteFile = mkPath
-
-  relativeFile : String → Path Rel File
-  relativeFile = mkPath
-
-  unsafeFromString : ∀ {k t} → String → Path k t
-  unsafeFromString  = mkPath
+  absolute : String → Path Abs
+  absolute = mkPath

--- a/src/System/Files.agda
+++ b/src/System/Files.agda
@@ -1,0 +1,41 @@
+module System.Files where
+
+open import System.FilePath
+open import Prelude.IO
+open import Prelude.String
+open import Prelude.Unit
+open import Prelude.Function
+open import Prelude.Bytes
+
+{-# IMPORT Data.ByteString #-}
+
+module Internal where
+  StrFilePath : Set
+  StrFilePath = String
+  
+  postulate
+    readTextFile  : StrFilePath → IO String
+    writeTextFile : StrFilePath → String → IO Unit
+
+    readBinaryFile  : StrFilePath → IO Bytes
+    writeBinaryFile : StrFilePath → Bytes → IO Unit
+
+  {-# COMPILED readTextFile  Data.Text.IO.readFile  . Data.Text.unpack #-}
+  {-# COMPILED writeTextFile Data.Text.IO.writeFile . Data.Text.unpack #-}
+  {-# COMPILED readBinaryFile Data.ByteString.readFile . Data.Text.unpack #-}
+  {-# COMPILED writeBinaryFile Data.ByteString.writeFile . Data.Text.unpack #-}
+
+  {-# COMPILED_UHC readTextFile  (UHC.Agda.Builtins.primReadFile) #-}
+  {-# COMPILED_UHC writeTextFile (UHC.Agda.Builtins.primWriteFile) #-}
+
+readTextFile : ∀ {a} → Path a File → IO String
+readTextFile = Internal.readTextFile ∘ toString
+
+writeTextFile : ∀ {a} → Path a File → String → IO Unit
+writeTextFile = Internal.writeTextFile ∘ toString
+
+readBinaryFile : ∀ {a} → Path a File → IO Bytes
+readBinaryFile = Internal.readBinaryFile ∘ toString
+
+writeBinaryFile : ∀ {a} → Path a File → Bytes → IO Unit
+writeBinaryFile = Internal.writeBinaryFile ∘ toString

--- a/src/System/Files.agda
+++ b/src/System/Files.agda
@@ -9,33 +9,34 @@ open import Prelude.Bytes
 
 {-# IMPORT Data.ByteString #-}
 
-module Internal where
-  StrFilePath : Set
-  StrFilePath = String
+private
+  module Internal where
+    StrFilePath : Set
+    StrFilePath = String
   
-  postulate
-    readTextFile  : StrFilePath → IO String
-    writeTextFile : StrFilePath → String → IO Unit
+    postulate
+      readTextFile  : StrFilePath → IO String
+      writeTextFile : StrFilePath → String → IO Unit
 
-    readBinaryFile  : StrFilePath → IO Bytes
-    writeBinaryFile : StrFilePath → Bytes → IO Unit
+      readBinaryFile  : StrFilePath → IO Bytes
+      writeBinaryFile : StrFilePath → Bytes → IO Unit
 
-  {-# COMPILED readTextFile  Data.Text.IO.readFile  . Data.Text.unpack #-}
-  {-# COMPILED writeTextFile Data.Text.IO.writeFile . Data.Text.unpack #-}
-  {-# COMPILED readBinaryFile Data.ByteString.readFile . Data.Text.unpack #-}
-  {-# COMPILED writeBinaryFile Data.ByteString.writeFile . Data.Text.unpack #-}
+    {-# COMPILED readTextFile  Data.Text.IO.readFile  . Data.Text.unpack #-}
+    {-# COMPILED writeTextFile Data.Text.IO.writeFile . Data.Text.unpack #-}
+    {-# COMPILED readBinaryFile Data.ByteString.readFile . Data.Text.unpack #-}
+    {-# COMPILED writeBinaryFile Data.ByteString.writeFile . Data.Text.unpack #-}
 
-  {-# COMPILED_UHC readTextFile  (UHC.Agda.Builtins.primReadFile) #-}
-  {-# COMPILED_UHC writeTextFile (UHC.Agda.Builtins.primWriteFile) #-}
+    {-# COMPILED_UHC readTextFile  (UHC.Agda.Builtins.primReadFile) #-}
+    {-# COMPILED_UHC writeTextFile (UHC.Agda.Builtins.primWriteFile) #-}
 
-readTextFile : ∀ {a} → Path a File → IO String
+readTextFile : ∀ {k} → Path k → IO String
 readTextFile = Internal.readTextFile ∘ toString
 
-writeTextFile : ∀ {a} → Path a File → String → IO Unit
+writeTextFile : ∀ {k} → Path k → String → IO Unit
 writeTextFile = Internal.writeTextFile ∘ toString
 
-readBinaryFile : ∀ {a} → Path a File → IO Bytes
+readBinaryFile : ∀ {k} → Path k → IO Bytes
 readBinaryFile = Internal.readBinaryFile ∘ toString
 
-writeBinaryFile : ∀ {a} → Path a File → Bytes → IO Unit
+writeBinaryFile : ∀ {k} → Path k → Bytes → IO Unit
 writeBinaryFile = Internal.writeBinaryFile ∘ toString

--- a/test/Files.agda
+++ b/test/Files.agda
@@ -5,7 +5,7 @@ open import System.Files
 open import System.FilePath
 open import Prelude.Equality
 
-fileIsEqual : ∀ {a b} → Path a File → Path b File → IO Unit
+fileIsEqual : ∀ {k} → Path k → Path k → IO Unit
 fileIsEqual a b = _≟_ <$> readBinaryFile a <*> readBinaryFile b >>= λ x →
   if x then return unit else exitWith (Failure 1)
   where
@@ -23,7 +23,7 @@ main =
   fileIsEqual fIn fTxtOut >>
   fileIsEqual fIn fBinOut
   where
-    fIn = relativeFile "Files.agda"
-    fTxtOut = relativeFile "test_files_txt.out"
-    fBinOut = relativeFile "test_files_bin.out"
+    fIn = relative "Files.agda"
+    fTxtOut = relative "test_files_txt.out"
+    fBinOut = relative "test_files_bin.out"
 

--- a/test/Files.agda
+++ b/test/Files.agda
@@ -1,0 +1,29 @@
+module Files where
+
+open import Prelude
+open import System.Files
+open import System.FilePath
+open import Prelude.Equality
+
+fileIsEqual : ∀ {a b} → Path a File → Path b File → IO Unit
+fileIsEqual a b = _≟_ <$> readBinaryFile a <*> readBinaryFile b >>= λ x →
+  if x then return unit else exitWith (Failure 1)
+  where
+    -- Move this to Prelude.Equality?
+    _≟_ : ∀ {a} {A : Set a} → {{eq : Eq A}} → A → A → Bool
+    x ≟ y = isYes (x == y)
+
+
+main : IO ⊤
+main =
+  readTextFile fIn >>=
+  writeTextFile fTxtOut >>
+  readBinaryFile fIn >>=
+  writeBinaryFile fBinOut >>
+  fileIsEqual fIn fTxtOut >>
+  fileIsEqual fIn fBinOut
+  where
+    fIn = relativeFile "Files.agda"
+    fTxtOut = relativeFile "test_files_txt.out"
+    fBinOut = relativeFile "test_files_bin.out"
+

--- a/test/Makefile
+++ b/test/Makefile
@@ -34,8 +34,9 @@ compile-files :
 	$(agda) Files.agda -c $(agda-flags)
 
 files-test : compile-files
-	@if [ "`./Files`" == "true" ]; \
+	@./Files; \
+   if [ $$? -eq 0 ]; \
 			then echo "OK"; \
-			else echo "Fail:\n`./PrimeTest`"; false; \
+			else echo "Fail:\n`./Files`"; false; \
 	 fi
 

--- a/test/Makefile
+++ b/test/Makefile
@@ -13,7 +13,7 @@ compile-main :
 compile-prime :
 	$(agda) PrimeTest.agda -c $(agda-flags)
 
-test : main-test prime-test
+test : main-test prime-test files-test
 
 main-test : everything
 	$(MAKE) compile-main agda-flags=--ignore-interfaces
@@ -26,6 +26,15 @@ main-test : everything
 
 prime-test : compile-prime
 	@if [ "`./PrimeTest`" == "true" ]; \
+			then echo "OK"; \
+			else echo "Fail:\n`./PrimeTest`"; false; \
+	 fi
+
+compile-files :
+	$(agda) Files.agda -c $(agda-flags)
+
+files-test : compile-files
+	@if [ "`./Files`" == "true" ]; \
 			then echo "OK"; \
 			else echo "Fail:\n`./PrimeTest`"; false; \
 	 fi


### PR DESCRIPTION
This adds basic implementations for bytestrings and file/directory operations.

I'm not sure yet what the best design for the FilePath type is. Should we index it by relative/absolute type?  Whether it points to a directory or file? The current design is inspired by the Haskell path library [1] . What complicates things is that listing directory contents only gives us the name of the items, but we do not know if an item is a file or a directory [2, 3]. Determining the type is an additional operation for each item.

What do you think?

[1] https://hackage.haskell.org/package/path-0.5.8/docs/Path.html
[2] http://hackage.haskell.org/package/directory-1.2.6.3/docs/System-Directory.html#v:getDirectoryContents
[3] http://linux.die.net/man/3/readdir