### PR TITLE
Add abs function for integers.

### DIFF
--- a/src/Builtin/Reflection.agda
+++ b/src/Builtin/Reflection.agda
@@ -1,7 +1,7 @@
 
 module Builtin.Reflection where
 
-open import Prelude
+open import Prelude hiding (abs)
 open import Prelude.Equality.Unsafe
 open import Builtin.Float
 open import Container.Traversable

--- a/src/Prelude/Int.agda
+++ b/src/Prelude/Int.agda
@@ -61,6 +61,10 @@ _-Z_ : Int → Int → Int
 a -Z b = a +Z negateInt b
 {-# INLINE _-Z_ #-}
 
+abs : Int → Nat
+abs (pos n) = n
+abs (negsuc n) = suc n
+
 _*Z_ : Int → Int → Int
 pos    a *Z pos    b = pos (a * b)
 pos    a *Z negsuc b = neg (a * suc b)
@@ -135,6 +139,11 @@ data LessInt (a b : Int) : Set where
   diff : (k : Nat) (eq : b ≡ pos (suc k) + a) → LessInt a b
 
 private
+
+  abs-neg-id : (a : Nat) → abs (neg a) ≡ a
+  abs-neg-id zero = refl
+  abs-neg-id (suc a) = refl
+
   nat-plus-zero : (a : Nat) → a + 0 ≡ a
   nat-plus-zero zero = refl
   nat-plus-zero (suc a) = suc $≡ nat-plus-zero a

--- a/src/Tactic/Deriving.agda
+++ b/src/Tactic/Deriving.agda
@@ -1,7 +1,7 @@
 
 module Tactic.Deriving where
 
-open import Prelude
+open import Prelude hiding (abs)
 open import Tactic.Reflection
 
 private

--- a/src/Tactic/Deriving/Eq.agda
+++ b/src/Tactic/Deriving/Eq.agda
@@ -1,5 +1,5 @@
 
-open import Prelude
+open import Prelude hiding (abs)
 open import Container.List
 open import Container.Traversable
 open import Tactic.Reflection hiding (substArgs) renaming (unify to unifyTC)

--- a/src/Tactic/Nat/Reflect.agda
+++ b/src/Tactic/Nat/Reflect.agda
@@ -1,7 +1,7 @@
 
 module Tactic.Nat.Reflect where
 
-open import Prelude
+open import Prelude hiding (abs)
 open import Control.Monad.State
 
 import Agda.Builtin.Nat as Builtin

--- a/src/Tactic/Nat/Simpl.agda
+++ b/src/Tactic/Nat/Simpl.agda
@@ -1,7 +1,7 @@
 
 module Tactic.Nat.Simpl where
 
-open import Prelude
+open import Prelude hiding (abs)
 open import Builtin.Reflection
 open import Tactic.Reflection.Quote
 open import Tactic.Reflection

--- a/src/Tactic/Nat/Subtract/By.agda
+++ b/src/Tactic/Nat/Subtract/By.agda
@@ -1,7 +1,7 @@
 
 module Tactic.Nat.Subtract.By where
 
-open import Prelude
+open import Prelude hiding (abs)
 open import Builtin.Reflection
 open import Tactic.Reflection.Quote
 open import Tactic.Reflection.DeBruijn

--- a/src/Tactic/Nat/Subtract/Simplify.agda
+++ b/src/Tactic/Nat/Subtract/Simplify.agda
@@ -1,7 +1,7 @@
 
 module Tactic.Nat.Subtract.Simplify where
 
-open import Prelude
+open import Prelude hiding (abs)
 open import Builtin.Reflection
 open import Tactic.Reflection.Quote
 open import Tactic.Reflection

--- a/src/Tactic/Reflection.agda
+++ b/src/Tactic/Reflection.agda
@@ -1,7 +1,7 @@
 
 module Tactic.Reflection where
 
-open import Prelude
+open import Prelude hiding (abs)
 open import Builtin.Reflection           public
 open import Tactic.Reflection.DeBruijn   public
 open import Tactic.Reflection.Telescope  public

--- a/src/Tactic/Reflection/DeBruijn.agda
+++ b/src/Tactic/Reflection/DeBruijn.agda
@@ -1,7 +1,7 @@
 
 module Tactic.Reflection.DeBruijn where
 
-open import Prelude
+open import Prelude hiding (abs)
 open import Builtin.Reflection
 open import Container.Traversable
 

--- a/src/Tactic/Reflection/Reright.agda
+++ b/src/Tactic/Reflection/Reright.agda
@@ -1,5 +1,5 @@
 module Tactic.Reflection.Reright where
-  open import Prelude
+  open import Prelude hiding (abs)
 
   open import Container.Traversable
 

--- a/src/Tactic/Reflection/Substitute.agda
+++ b/src/Tactic/Reflection/Substitute.agda
@@ -1,7 +1,7 @@
 
 module Tactic.Reflection.Substitute where
 
-open import Prelude
+open import Prelude hiding (abs)
 open import Builtin.Reflection
 open import Tactic.Reflection.DeBruijn
 

--- a/src/Tactic/Reflection/Telescope.agda
+++ b/src/Tactic/Reflection/Telescope.agda
@@ -1,7 +1,7 @@
 
 module Tactic.Reflection.Telescope where
 
-open import Prelude
+open import Prelude hiding (abs)
 open import Builtin.Reflection
 open import Tactic.Reflection.DeBruijn
 


### PR DESCRIPTION
The name collides with the ``abs`` constructor in reflection, so I had to hide the new function in some imports. The name collision is not so nice, but I think the integer ``abs`` function needs to have this name, as that's what every other language calls it. Also, the main ``Prelude`` module doesn't import the reflection ``abs``, so people just using ``open import Prelude`` without reflection are not affected.