### PR TITLE
Add some monad transformers

### DIFF
--- a/src/Control/Monad/Except.agda
+++ b/src/Control/Monad/Except.agda
@@ -1,0 +1,63 @@
+
+module Control.Monad.Except where
+
+open import Prelude
+open import Control.Monad.Zero
+open import Control.Monad.Identity
+open import Control.Monad.Transformer
+
+record ExceptT {a} (E : Set a) (M : Set a → Set a) (A : Set a) : Set a where
+  no-eta-equality
+  constructor maybeT
+  field runExceptT : M (Either E A)
+
+open ExceptT public
+
+module _ {a} {E : Set a} {M : Set a → Set a} where
+
+  instance
+    FunctorExceptT : {{_ : Functor M}} → Functor {a = a} (ExceptT E M)
+    runExceptT (fmap {{FunctorExceptT}} f m) = fmap f <$> runExceptT m
+
+    FunctorZeroExceptT : {{_ : Monad M}} {{_ : Monoid E}} → FunctorZero {a = a} (ExceptT E M)
+    runExceptT (empty {{FunctorZeroExceptT}}) = return (left mempty)
+
+    AlternativeExceptT : {{_ : Monad M}} {{_ : Monoid E}} → Alternative {a = a} (ExceptT E M)
+    runExceptT (_<|>_ {{AlternativeExceptT {{monadM}}}} mx my) = do
+      right x ← runExceptT mx
+        where
+          left e₁ → do
+            right y ← runExceptT my
+              where left e₂ → return (left (e₁ <> e₂))
+            return (right y)
+      return (right x)
+
+  module _ {{_ : Monad M}} where
+
+    private
+      bindExceptT : ∀ {A B} → ExceptT E M A → (A → ExceptT E M B) → ExceptT E M B
+      runExceptT (bindExceptT m f) = do
+        right x ← runExceptT m
+          where left e → return (left e)
+        runExceptT (f x)
+
+    instance
+      ApplicativeExceptT : Applicative {a = a} (ExceptT E M)
+      runExceptT (pure {{ApplicativeExceptT}} x) = pure (right x)
+      _<*>_ {{ApplicativeExceptT}} = monadAp bindExceptT
+
+      MonadExceptT : Monad {a = a} (ExceptT E M)
+      _>>=_  {{MonadExceptT}} = bindExceptT
+
+    liftExceptT : {A : Set a} → M A → ExceptT E M A
+    runExceptT (liftExceptT m) = right <$> m
+
+instance
+  TransformerExceptT : ∀ {a} {E : Set a} → Transformer {a} (ExceptT E)
+  lift {{TransformerExceptT}} = liftExceptT
+
+Except : ∀ {a} (E : Set a) (A : Set a) → Set a
+Except R = ExceptT R Identity
+
+runExcept : ∀ {a} {E : Set a} {A : Set a} → Except E A → Either E A
+runExcept m = runIdentity (runExceptT m)

--- a/src/Control/Monad/Maybe.agda
+++ b/src/Control/Monad/Maybe.agda
@@ -1,0 +1,52 @@
+
+module Control.Monad.Maybe where
+
+open import Prelude
+open import Control.Monad.Zero
+open import Control.Monad.Transformer
+
+record MaybeT {a} (M : Set a → Set a) (A : Set a) : Set a where
+  no-eta-equality
+  constructor maybeT
+  field runMaybeT : M (Maybe A)
+
+open MaybeT public
+
+module _ {a} {M : Set a → Set a} where
+
+  instance
+    FunctorMaybeT : {{_ : Functor M}} → Functor {a = a} (MaybeT M)
+    runMaybeT (fmap {{FunctorMaybeT}} f m) = fmap f <$> runMaybeT m
+
+    FunctorZeroMaybeT : {{_ : Monad M}} → FunctorZero {a = a} (MaybeT M)
+    runMaybeT (empty {{FunctorZeroMaybeT}}) = return nothing
+
+    AlternativeMaybeT : {{_ : Monad M}} → Alternative {a = a} (MaybeT M)
+    runMaybeT (_<|>_ {{AlternativeMaybeT {{monadM}}}} mx my) = do
+      just x ← runMaybeT mx
+        where nothing → runMaybeT my
+      return (just x)
+
+  module _ {{_ : Monad M}} where
+
+    private
+      bindMaybeT : ∀ {A B} → MaybeT M A → (A → MaybeT M B) → MaybeT M B
+      runMaybeT (bindMaybeT m f) = do
+        just x ← runMaybeT m
+          where nothing → return nothing
+        runMaybeT (f x)
+
+    instance
+      ApplicativeMaybeT : Applicative {a = a} (MaybeT M)
+      runMaybeT (pure {{ApplicativeMaybeT}} x) = pure (just x)
+      _<*>_ {{ApplicativeMaybeT}} = monadAp bindMaybeT
+
+      MonadMaybeT : Monad {a = a} (MaybeT M)
+      _>>=_  {{MonadMaybeT}} = bindMaybeT
+
+    liftMaybeT : {A : Set a} → M A → MaybeT M A
+    runMaybeT (liftMaybeT m) = just <$> m
+
+instance
+  TransformerMaybeT : ∀ {a} → Transformer {a} MaybeT
+  lift {{TransformerMaybeT}} = liftMaybeT

--- a/src/Control/Monad/Reader.agda
+++ b/src/Control/Monad/Reader.agda
@@ -1,0 +1,57 @@
+
+module Control.Monad.Reader where
+
+open import Prelude
+open import Control.Monad.Zero
+open import Control.Monad.Identity
+
+record ReaderT {a} (R : Set a) (M : Set a → Set a) (A : Set a) : Set a where
+  no-eta-equality
+  constructor readerT
+  field runReaderT : R → M A
+
+open ReaderT public
+
+module _ {a} {R : Set a} {M : Set a → Set a} where
+
+  instance
+    FunctorReaderT : {{_ : Functor M}} → Functor {a = a} (ReaderT R M)
+    runReaderT (fmap {{ FunctorReaderT }} f m) r = f <$> runReaderT m r
+
+    FunctorZeroReaderT : {{_ : FunctorZero M}} → FunctorZero {a = a} (ReaderT R M)
+    runReaderT (empty {{FunctorZeroReaderT}}) r = empty
+
+    AlternativeReaderT : {{_ : Alternative M}} → Alternative {a = a} (ReaderT R M)
+    runReaderT (_<|>_ {{AlternativeReaderT}} x y) r = runReaderT x r <|> runReaderT y r
+
+  module _ {{_ : Monad M}} where
+
+    private
+      bindReaderT : ∀ {A B} → ReaderT R M A → (A → ReaderT R M B) → ReaderT R M B
+      runReaderT (bindReaderT m f) r = runReaderT m r >>= λ x → runReaderT (f x) r
+
+    instance
+      ApplicativeReaderT : Applicative {a = a} (ReaderT R M)
+      runReaderT (pure {{ApplicativeReaderT}} x) r = pure x
+      _<*>_ {{ApplicativeReaderT}} = monadAp bindReaderT
+
+      MonadReaderT : Monad {a = a} (ReaderT R M)
+      _>>=_  {{MonadReaderT}} = bindReaderT
+
+    lift : {A : Set a} → M A → ReaderT R M A
+    runReaderT (lift m) r = m
+
+    asks : {A : Set a} → (R → A) → ReaderT R M A
+    runReaderT (asks f) r = return (f r)
+
+    ask : ReaderT R M R
+    ask = asks id
+
+    local : {A : Set a} → (R → R) → ReaderT R M A → ReaderT R M A
+    runReaderT (local f m) r = runReaderT m (f r)
+
+Reader : ∀ {a} (R : Set a) (A : Set a) → Set a
+Reader R = ReaderT R Identity
+
+runReader : ∀ {a} {R : Set a} {A : Set a} → Reader R A → R → A
+runReader m r = runIdentity (runReaderT m r)

--- a/src/Control/Monad/Reader.agda
+++ b/src/Control/Monad/Reader.agda
@@ -4,6 +4,7 @@ module Control.Monad.Reader where
 open import Prelude
 open import Control.Monad.Zero
 open import Control.Monad.Identity
+open import Control.Monad.Transformer
 
 record ReaderT {a} (R : Set a) (M : Set a → Set a) (A : Set a) : Set a where
   no-eta-equality
@@ -38,8 +39,8 @@ module _ {a} {R : Set a} {M : Set a → Set a} where
       MonadReaderT : Monad {a = a} (ReaderT R M)
       _>>=_  {{MonadReaderT}} = bindReaderT
 
-    lift : {A : Set a} → M A → ReaderT R M A
-    runReaderT (lift m) r = m
+    liftReaderT : {A : Set a} → M A → ReaderT R M A
+    runReaderT (liftReaderT m) r = m
 
     asks : {A : Set a} → (R → A) → ReaderT R M A
     runReaderT (asks f) r = return (f r)
@@ -49,6 +50,10 @@ module _ {a} {R : Set a} {M : Set a → Set a} where
 
     local : {A : Set a} → (R → R) → ReaderT R M A → ReaderT R M A
     runReaderT (local f m) r = runReaderT m (f r)
+
+instance
+  TransformerReaderT : ∀ {a} {R : Set a} → Transformer (ReaderT R)
+  lift {{TransformerReaderT}} = liftReaderT
 
 Reader : ∀ {a} (R : Set a) (A : Set a) → Set a
 Reader R = ReaderT R Identity

--- a/src/Control/Monad/State.agda
+++ b/src/Control/Monad/State.agda
@@ -4,6 +4,7 @@ module Control.Monad.State where
 open import Prelude
 open import Control.Monad.Zero
 open import Control.Monad.Identity
+open import Control.Monad.Transformer
 
 record StateT {a} (S : Set a) (M : Set a → Set a) (A : Set a) : Set a where
   no-eta-equality
@@ -40,8 +41,8 @@ module _ {a} {S : Set a} {M : Set a → Set a} where
       MonadStateT : Monad {a = a} (StateT S M)
       _>>=_  {{MonadStateT}} = bindStateT
 
-    lift : {A : Set a} → M A → StateT S M A
-    runStateT (lift m) s = m >>= λ x → return (x , s)
+    liftStateT : {A : Set a} → M A → StateT S M A
+    runStateT (liftStateT m) s = m >>= λ x → return (x , s)
 
     gets : {A : Set a} → (S → A) → StateT S M A
     runStateT (gets f) s = return (f s , s)
@@ -54,6 +55,10 @@ module _ {a} {S : Set a} {M : Set a → Set a} where
 
     put : S → StateT S M S
     put s = modify (const s)
+
+instance
+  TransformerStateT : ∀ {a} {S : Set a} → Transformer (StateT S)
+  lift {{TransformerStateT}} = liftStateT
 
 State : ∀ {a} (S : Set a) (A : Set a) → Set a
 State S = StateT S Identity

--- a/src/Control/Monad/State.agda
+++ b/src/Control/Monad/State.agda
@@ -3,6 +3,7 @@ module Control.Monad.State where
 
 open import Prelude
 open import Control.Monad.Zero
+open import Control.Monad.Identity
 
 record StateT {a} (S : Set a) (M : Set a → Set a) (A : Set a) : Set a where
   no-eta-equality
@@ -53,3 +54,12 @@ module _ {a} {S : Set a} {M : Set a → Set a} where
 
     put : S → StateT S M S
     put s = modify (const s)
+
+State : ∀ {a} (S : Set a) (A : Set a) → Set a
+State S = StateT S Identity
+
+runState : ∀ {a} {S : Set a} {A : Set a} → State S A → S → A × S
+runState m s = runIdentity (runStateT m s)
+
+execState : ∀ {a} {S : Set a} {A : Set a} → State S A → S → S
+execState m s = snd (runState m s)

--- a/src/Control/Monad/Transformer.agda
+++ b/src/Control/Monad/Transformer.agda
@@ -1,0 +1,10 @@
+
+module Control.Monad.Transformer where
+
+open import Prelude
+
+record Transformer {a b} (T : (Set a → Set b) → (Set a → Set b)) : Set (lsuc a ⊔ lsuc b) where
+  field
+    lift : {M : Set a → Set b} {{_ : Monad M}} {A : Set a} → M A → T M A
+
+open Transformer {{...}} public

--- a/src/Control/Monad/Writer.agda
+++ b/src/Control/Monad/Writer.agda
@@ -1,0 +1,77 @@
+
+module Control.Monad.Writer where
+
+open import Prelude
+open import Control.Monad.Zero
+open import Control.Monad.Identity
+
+record WriterT {a} (W : Set a) (M : Set a → Set a) (A : Set a) : Set a where
+  no-eta-equality
+  constructor writerT
+  field runWriterT : M (A × W)
+
+open WriterT public
+
+module _ {a} {W : Set a} {M : Set a → Set a} where
+
+  instance
+    FunctorWriterT : {{_ : Functor M}} → Functor {a = a} (WriterT W M)
+    runWriterT (fmap {{ FunctorWriterT }} f m) = first f <$> runWriterT m
+
+    FunctorZeroWriterT : {{_ : FunctorZero M}} → FunctorZero {a = a} (WriterT W M)
+    runWriterT (empty {{FunctorZeroWriterT}}) = empty
+
+    AlternativeWriterT : {{_ : Alternative M}} → Alternative {a = a} (WriterT W M)
+    runWriterT (_<|>_ {{AlternativeWriterT}} x y) = runWriterT x <|> runWriterT y
+
+  module _ {{_ : Monoid W}} {{_ : Monad M}} where
+
+    private
+      bindWriterT : ∀ {A B} → WriterT W M A → (A → WriterT W M B) → WriterT W M B
+      runWriterT (bindWriterT m f) = do
+        (x , w₁) ← runWriterT m
+        (y , w₂) ← (runWriterT (f x))
+        return (y , w₁ <> w₂)
+
+    instance
+      ApplicativeWriterT : Applicative {a = a} (WriterT W M)
+      runWriterT (pure {{ApplicativeWriterT}} x) = return (x , mempty)
+      _<*>_ {{ApplicativeWriterT}} = monadAp bindWriterT
+
+      MonadWriterT : Monad {a = a} (WriterT W M)
+      _>>=_  {{MonadWriterT}} = bindWriterT
+
+    lift : {A : Set a} → M A → WriterT W M A
+    runWriterT (lift m) = (_, mempty) <$> m
+
+    writer : {A : Set a} → A × W → WriterT W M A
+    runWriterT (writer (x , w)) = return (x , w)
+
+    tell : W → WriterT W M ⊤′
+    runWriterT (tell w) = return (tt , w)
+
+    listens : {A B : Set a} → (W → B) → WriterT W M A → WriterT W M (A × B)
+    runWriterT (listens f m) = do
+      (x , w) ← runWriterT m
+      return ((x , f w) , w)
+
+    listen : {A : Set a} → WriterT W M A → WriterT W M (A × W)
+    listen = listens id
+
+    pass : {A : Set a} → WriterT W M (A × (W → W)) → WriterT W M A
+    runWriterT (pass m) = do
+      ((x , f) , w) ← runWriterT m
+      return (x , f w)
+
+    censor : {A : Set a} → (W → W) → WriterT W M A → WriterT W M A
+    censor f m = pass ((_, f) <$> m)
+
+
+Writer : ∀ {a} (W : Set a) (A : Set a) → Set a
+Writer W = WriterT W Identity
+
+runWriter : ∀ {a} {W : Set a} {A : Set a} → Writer W A → A × W
+runWriter m = runIdentity (runWriterT m)
+
+execWriter : ∀ {a} {W : Set a} {A : Set a} → Writer W A → W
+execWriter = snd ∘ runWriter

--- a/src/Control/Monad/Writer.agda
+++ b/src/Control/Monad/Writer.agda
@@ -4,6 +4,7 @@ module Control.Monad.Writer where
 open import Prelude
 open import Control.Monad.Zero
 open import Control.Monad.Identity
+open import Control.Monad.Transformer
 
 record WriterT {a} (W : Set a) (M : Set a → Set a) (A : Set a) : Set a where
   no-eta-equality
@@ -41,8 +42,8 @@ module _ {a} {W : Set a} {M : Set a → Set a} where
       MonadWriterT : Monad {a = a} (WriterT W M)
       _>>=_  {{MonadWriterT}} = bindWriterT
 
-    lift : {A : Set a} → M A → WriterT W M A
-    runWriterT (lift m) = (_, mempty) <$> m
+    liftWriterT : {A : Set a} → M A → WriterT W M A
+    runWriterT (liftWriterT m) = (_, mempty) <$> m
 
     writer : {A : Set a} → A × W → WriterT W M A
     runWriterT (writer (x , w)) = return (x , w)
@@ -66,6 +67,9 @@ module _ {a} {W : Set a} {M : Set a → Set a} where
     censor : {A : Set a} → (W → W) → WriterT W M A → WriterT W M A
     censor f m = pass ((_, f) <$> m)
 
+instance
+  TransformerWriterT : ∀ {a} {W : Set a} {{_ : Monoid W}} → Transformer (WriterT W)
+  lift {{TransformerWriterT}} = liftWriterT
 
 Writer : ∀ {a} (W : Set a) (A : Set a) → Set a
 Writer W = WriterT W Identity


### PR DESCRIPTION
How can this be a library for 'practical programming' yet not even have some standard monad transformers? Here are ReaderT and WriterT for starters. I tried to keep the standard names from Haskell where possible.

Don't merge yet, I'm planning to add some more later.