### PR TITLE
Indexed monads

### DIFF
--- a/src/Prelude/Applicative.agda
+++ b/src/Prelude/Applicative.agda
@@ -10,51 +10,20 @@ open import Prelude.Number
 open import Prelude.Semiring
 open import Prelude.Fractional
 
-record Applicative {a b} (F : Set a → Set b) : Set (lsuc a ⊔ b) where
-  infixl 4 _<*>_ _<*_ _*>_
-  field
-    pure  : ∀ {A} → A → F A
-    _<*>_ : ∀ {A B} → F (A → B) → F A → F B
-    overlap {{super}} : Functor F
+open import Prelude.Applicative.Indexed {I = ⊤} as Indexed
 
-  _<*_ : ∀ {A B} → F A → F B → F A
-  a <* b = ⦇ const a b ⦈
+Applicative : ∀ {a b} (F : Set a → Set b) → Set (lsuc a ⊔ b)
+Applicative F = Indexed.IApplicative (λ _ _ → F)
 
-  _*>_ : ∀ {A B} → F A → F B → F B
-  a *> b = ⦇ (const id) a b ⦈
+Applicative′ : ∀ {a b} (F : ∀ {a} → Set a → Set a) → Set (lsuc (a ⊔ b))
+Applicative′ {a} {b} F = Indexed.IApplicative′ {a = a} {b = b} (λ _ _ → F)
 
-open Applicative {{...}} public
-
-{-# DISPLAY Applicative.pure  _ = pure  #-}
-{-# DISPLAY Applicative._<*>_ _ = _<*>_ #-}
-{-# DISPLAY Applicative._<*_  _ = _<*_  #-}
-{-# DISPLAY Applicative._*>_  _ = _*>_  #-}
+open Indexed public hiding (IApplicative; IApplicative′)
 
 fmapApplicative : ∀ {a b} {F : Set a → Set b} →
                     (∀ {A} → A → F A) → (∀ {A B} → F (A → B) → F A → F B) →
                     ∀ {A B} → (A → B) → F A → F B
 fmapApplicative pure _<*>_ f m = pure f <*> m
-
--- Level polymorphic functors
-record Applicative′ {a b} (F : ∀ {a} → Set a → Set a) : Set (lsuc (a ⊔ b)) where
-  infixl 4 _<*>′_
-  field
-    _<*>′_ : {A : Set a} {B : Set b} → F (A → B) → F A → F B
-    overlap {{super}} : Functor′ {a} {b} F
-
-open Applicative′ {{...}} public
-
-module _ {F : ∀ {a} → Set a → Set a}
-         {{_ : ∀ {a} → Applicative {a} F}}
-         {{_ : ∀ {a b} → Applicative′ {a} {b} F}}
-         {a b} {A : Set a} {B : Set b} where
-
-  infixl 4 _<*′_ _*>′_
-  _<*′_ : F A → F B → F A
-  a <*′ b = pure const <*>′ a <*>′ b
-
-  _*>′_ : F A → F B → F B
-  a *>′ b = pure (const id) <*>′ a <*>′ b
 
 module _ {a b} {F : Set a → Set b} {{AppF : Applicative F}} where
 

--- a/src/Prelude/Applicative/Indexed.agda
+++ b/src/Prelude/Applicative/Indexed.agda
@@ -1,0 +1,52 @@
+
+module Prelude.Applicative.Indexed {i} {I : Set i} where
+
+open import Agda.Primitive
+open import Prelude.Unit
+open import Prelude.Functor
+open import Prelude.Function
+open import Prelude.Equality
+open import Prelude.Number
+open import Prelude.Semiring
+open import Prelude.Fractional
+
+record IApplicative {a b} (F : I → I → Set a → Set b) : Set (i ⊔ lsuc a ⊔ b) where
+  infixl 4 _<*>_ _<*_ _*>_
+  field
+    pure  : ∀ {A i} → A → F i i A
+    _<*>_ : ∀ {A B i j k} → F i j (A → B) → F j k A → F i k B
+    overlap {{super}} : ∀ {i j} → Functor (F i j)
+
+  _<*_ : ∀ {A B i j k} → F i j A → F j k B → F i k A
+  a <* b = ⦇ const a b ⦈
+
+  _*>_ : ∀ {A B i j k} → F i j A → F j k B → F i k B
+  a *> b = ⦇ (const id) a b ⦈
+
+open IApplicative {{...}} public
+
+{-# DISPLAY IApplicative.pure  _ = pure  #-}
+{-# DISPLAY IApplicative._<*>_ _ = _<*>_ #-}
+{-# DISPLAY IApplicative._<*_  _ = _<*_  #-}
+{-# DISPLAY IApplicative._*>_  _ = _*>_  #-}
+
+-- Level polymorphic functors
+record IApplicative′ {a b} (F : ∀ {a} → I → I → Set a → Set a) : Set (i ⊔ lsuc (a ⊔ b)) where
+  infixl 4 _<*>′_
+  field
+    _<*>′_ : {A : Set a} {B : Set b} {i j k : I} → F i j (A → B) → F j k A → F i k B
+    overlap {{super}} : ∀ {i j} → Functor′ {a} {b} (F i j)
+
+open IApplicative′ {{...}} public
+
+module _ {F : ∀ {a} → I → I → Set a → Set a}
+         {{_ : ∀ {a} → IApplicative {a = a} F}}
+         {{_ : ∀ {a b} → IApplicative′ {a = a} {b = b} F}}
+         {a b} {A : Set a} {B : Set b} {i j k} where
+
+  infixl 4 _<*′_ _*>′_
+  _<*′_ : F i j A → F j k B → F i k A
+  a <*′ b = pure const <*>′ a <*>′ b
+
+  _*>′_ : F i j A → F j k B → F i k B
+  a *>′ b = pure (const id) <*>′ a <*>′ b

--- a/src/Prelude/Monad.agda
+++ b/src/Prelude/Monad.agda
@@ -4,50 +4,24 @@ module Prelude.Monad where
 open import Agda.Primitive
 open import Prelude.Function
 open import Prelude.Functor
+open import Prelude.Unit
 open import Prelude.Applicative
 
-record Monad {a b} (M : Set a → Set b) : Set (lsuc a ⊔ b) where
-  infixr 1 _=<<_
-  infixl 1 _>>=_ _>>_
-  field
-    _>>=_ : ∀ {A B} → M A → (A → M B) → M B
-    overlap {{super}} : Applicative M
+open import Prelude.Monad.Indexed {I = ⊤} as Indexed
 
-  _>>_ : ∀ {A B} → M A → M B → M B
-  m₁ >> m₂ = m₁ >>= λ _ → m₂
+Monad : ∀ {a b} (M : Set a → Set b) → Set (lsuc a ⊔ b)
+Monad M = Indexed.IMonad (λ _ _ → M)
 
-  _=<<_ : ∀ {A B} → (A → M B) → M A → M B
-  _=<<_ = flip _>>=_
+Monad′ : ∀ {a b} (M : ∀ {a} → Set a → Set a) → Set (lsuc (a ⊔ b))
+Monad′ {a} {b} M = Indexed.IMonad′ {a = a} {b = b} (λ _ _ → M)
 
-return : ∀ {a b} {A : Set a} {M : Set a → Set b} {{_ : Monad M}} → A → M A
-return = pure
+open Indexed public hiding (IMonad; IMonad′)
 
 monadAp : ∀ {a b} {A B : Set a} {M : Set a → Set b}
             {{_ : Functor M}} →
             (M (A → B) → ((A → B) → M B) → M B) →
             M (A → B) → M A → M B
 monadAp _>>=_ mf mx = mf >>= λ f → fmap f mx
-
-open Monad {{...}} public
-
-{-# DISPLAY Monad._>>=_  _ = _>>=_  #-}
-{-# DISPLAY Monad._=<<_  _ = _=<<_  #-}
-{-# DISPLAY Monad._>>_   _ = _>>_   #-}
-
-join : ∀ {a} {M : Set a → Set a} {{_ : Monad M}} {A : Set a} → M (M A) → M A
-join = _=<<_ id
-
--- Level polymorphic monads
-record Monad′ {a b} (M : ∀ {a} → Set a → Set a) : Set (lsuc (a ⊔ b)) where
-  field
-    _>>=′_ : {A : Set a} {B : Set b} → M A → (A → M B) → M B
-    overlap {{super}} : Applicative′ {a} {b} M
-
-  _>>′_ : {A : Set a} {B : Set b} → M A → M B → M B
-  m >>′ m′ = m >>=′ λ _ → m′
-
-open Monad′ {{...}} public
-
 
 monadAp′ : ∀ {a b} {A : Set a} {B : Set b} {M : ∀ {a} → Set a → Set a}
              {{_ : Functor′ {a} {b} M}} →

--- a/src/Prelude/Monad/Indexed.agda
+++ b/src/Prelude/Monad/Indexed.agda
@@ -1,0 +1,45 @@
+
+module Prelude.Monad.Indexed {i} {I : Set i} where
+
+open import Agda.Primitive
+open import Prelude.Function
+open import Prelude.Functor
+open import Prelude.Applicative.Indexed {I = I}
+
+record IMonad {a b} (M : I → I → Set a → Set b) : Set (i ⊔ lsuc a ⊔ b) where
+  infixr 1 _=<<_
+  infixl 1 _>>=_ _>>_
+  field
+    _>>=_ : ∀ {A B i j k} → M i j A → (A → M j k B) → M i k B
+    overlap {{super}} : IApplicative M
+
+  _>>_ : ∀ {A B i j k} → M i j A → M j k B → M i k B
+  m₁ >> m₂ = m₁ >>= λ _ → m₂
+
+  _=<<_ : ∀ {A B i j k} → (A → M j k B) → M i j A → M i k B
+  _=<<_ = flip _>>=_
+
+return : ∀ {a b} {A : Set a} {M : I → I → Set a → Set b} {{_ : IMonad M}}
+         {i : I} → A → M i i A
+return = pure
+
+open IMonad {{...}} public
+
+{-# DISPLAY IMonad._>>=_  _ = _>>=_  #-}
+{-# DISPLAY IMonad._=<<_  _ = _=<<_  #-}
+{-# DISPLAY IMonad._>>_   _ = _>>_   #-}
+
+join : ∀ {a} {M : I → I → Set a → Set a} {{_ : IMonad M}} {A : Set a}
+       {i j k} → M i j (M j k A) → M i k A
+join = _=<<_ id
+
+-- Level polymorphic monads
+record IMonad′ {a b} (M : ∀ {a} → I → I → Set a → Set a) : Set (i ⊔ lsuc (a ⊔ b)) where
+  field
+    _>>=′_ : {A : Set a} {B : Set b} {i j k : I} → M i j A → (A → M j k B) → M i k B
+    overlap {{super}} : IApplicative′ {a} {b} M
+
+  _>>′_ : {A : Set a} {B : Set b} {i j k : I} → M i j A → M j k B → M i k B
+  m >>′ m′ = m >>=′ λ _ → m′
+
+open IMonad′ {{...}} public


### PR DESCRIPTION
I needed indexed monads for keeping track of the variables that are in scope in the implementation of a correct-by-construction typechecker, so I decided to add them to the prelude. There are no instances yet but I think that's quite natural since most of the time the index type is application-specific. Maybe it would make sense to have a general instance for an indexed state monad where the index keeps track of the 'shape' of the current state.