### PR TITLE
Add a small macro for making arguments explicit

### DIFF
--- a/src/Builtin/Reflection.agda
+++ b/src/Builtin/Reflection.agda
@@ -133,7 +133,7 @@ instance
   traverse {{TraversableAbs}} f (abs s x) = ⦇ (abs s) (f x) ⦈
 
 absurd-lam : Term
-absurd-lam = pat-lam (absurd-clause (vArg absurd ∷ []) ∷ []) []
+absurd-lam = pat-lam (absurd-clause (("()" , vArg unknown) ∷ []) (vArg absurd ∷ []) ∷ []) []
 
 --- TC monad ---
 
@@ -309,6 +309,9 @@ pcon-inj₂ refl = refl
 pvar-inj : ∀ {x y} → Pattern.var x ≡ var y → x ≡ y
 pvar-inj refl = refl
 
+pdot-inj : ∀ {x y} → Pattern.dot x ≡ dot y → x ≡ y
+pdot-inj refl = refl
+
 plit-inj : ∀ {x y} → Pattern.lit x ≡ lit y → x ≡ y
 plit-inj refl = refl
 
@@ -317,14 +320,20 @@ proj-inj refl = refl
 
 --- Clauses ---
 
-clause-inj₁ : ∀ {x y z w} → clause x y ≡ clause z w → x ≡ z
+clause-inj₁ : ∀ {x y z u v w} → clause x y z ≡ clause u v w → x ≡ u
 clause-inj₁ refl = refl
 
-clause-inj₂ : ∀ {x y z w} → clause x y ≡ clause z w → y ≡ w
+clause-inj₂ : ∀ {x y z u v w} → clause x y z ≡ clause u v w → y ≡ v
 clause-inj₂ refl = refl
 
-absurd-clause-inj : ∀ {x y} → absurd-clause x ≡ absurd-clause y → x ≡ y
-absurd-clause-inj refl = refl
+clause-inj₃ : ∀ {x y z u v w} → clause x y z ≡ clause u v w → z ≡ w
+clause-inj₃ refl = refl
+
+absurd-clause-inj₁ : ∀ {x y z w} → absurd-clause x y ≡ absurd-clause z w → x ≡ z
+absurd-clause-inj₁ refl = refl
+
+absurd-clause-inj₂ : ∀ {x y z w} → absurd-clause x y ≡ absurd-clause z w → y ≡ w
+absurd-clause-inj₂ refl = refl
 
 --- Literals ---
 

--- a/src/Numeric/Nat/GCD.agda
+++ b/src/Numeric/Nat/GCD.agda
@@ -14,6 +14,7 @@ open import Tactic.Nat
 record IsGCD (d a b : Nat) : Set where
   no-eta-equality
   constructor is-gcd
+  pattern
   field d|a : d Divides a
         d|b : d Divides b
         g   : ∀ k → k Divides a → k Divides b → k Divides d
@@ -21,6 +22,7 @@ record IsGCD (d a b : Nat) : Set where
 record GCD (a b : Nat) : Set where
   no-eta-equality
   constructor gcd-res
+  pattern
   field d     : Nat
         isGCD : IsGCD d a b
 

--- a/src/Numeric/Nat/GCD/Extended.agda
+++ b/src/Numeric/Nat/GCD/Extended.agda
@@ -28,6 +28,7 @@ data BézoutIdentity (d a b : Nat) : Set where
 record ExtendedGCD (a b : Nat) : Set where
   no-eta-equality
   constructor gcd-res
+  pattern
   field d      : Nat
         isGCD  : IsGCD d a b
         bézout : BézoutIdentity d a b
@@ -41,6 +42,7 @@ private
   record ExtendedGCD′ (a b r₀ r₁ : Nat) : Set where
     no-eta-equality
     constructor gcd-res
+    pattern
     field d      : Nat
           isGCD  : IsGCD d r₀ r₁
           bézout : BézoutIdentity d a b

--- a/src/Numeric/Nat/LCM.agda
+++ b/src/Numeric/Nat/LCM.agda
@@ -15,6 +15,7 @@ open import Tactic.Nat
 record IsLCM m a b : Set where
   no-eta-equality
   constructor is-lcm
+  pattern
   field
     a|m : a Divides m
     b|m : b Divides m
@@ -23,6 +24,7 @@ record IsLCM m a b : Set where
 record LCM a b : Set where
   no-eta-equality
   constructor lcm-res
+  pattern
   field
     m : Nat
     isLCM : IsLCM m a b

--- a/src/Numeric/Nat/Prime/FundamentalTheorem.agda
+++ b/src/Numeric/Nat/Prime/FundamentalTheorem.agda
@@ -41,6 +41,7 @@ private
 record Factorisation (n : Nat) : Set where
   no-eta-equality
   constructor mkFactors
+  pattern
   field
     factors       : List Nat
     factors-prime : All Prime factors

--- a/src/Numeric/Rational.agda
+++ b/src/Numeric/Rational.agda
@@ -16,6 +16,7 @@ open import Tactic.Nat.Coprime
 record Rational : Set where
   no-eta-equality
   constructor ratio
+  pattern
   field numerator   : Nat
         denominator : Nat
         ⦃ d>0 ⦄    : NonZero denominator

--- a/src/Prelude/Equality.agda
+++ b/src/Prelude/Equality.agda
@@ -64,6 +64,16 @@ decEq₂ f-inj₁ f-inj₂ (no neq)    _         = no λ eq → neq (f-inj₁ eq
 decEq₂ f-inj₁ f-inj₂  _         (no neq)   = no λ eq → neq (f-inj₂ eq)
 decEq₂ f-inj₁ f-inj₂ (yes refl) (yes refl) = yes refl
 
+decEq₃ : ∀ {a b c d} {A : Set a} {B : Set b} {C : Set c} {D : Set d} {f : A → B → C → D} →
+           (∀ {x y z u v w} → f x y z ≡ f u v w → x ≡ u) →
+           (∀ {x y z u v w} → f x y z ≡ f u v w → y ≡ v) →
+           (∀ {x y z u v w} → f x y z ≡ f u v w → z ≡ w) →
+           ∀ {x y z u v w} → Dec (x ≡ u) → Dec (y ≡ v) → Dec (z ≡ w) → Dec (f x y z ≡ f u v w)
+decEq₃ f-inj₁ f-inj₂ f-inj₃ (no neq)    _         _          = no λ eq → neq (f-inj₁ eq)
+decEq₃ f-inj₁ f-inj₂ f-inj₃  _         (no neq)   _          = no λ eq → neq (f-inj₂ eq)
+decEq₃ f-inj₁ f-inj₂ f-inj₃  _         _          (no neq)   = no λ eq → neq (f-inj₃ eq)
+decEq₃ f-inj₁ f-inj₂ f-inj₃ (yes refl) (yes refl) (yes refl) = yes refl
+
 {-# INLINE decEq₁ #-}
 {-# INLINE decEq₂ #-}
 

--- a/src/Prelude/Product.agda
+++ b/src/Prelude/Product.agda
@@ -63,6 +63,14 @@ sigma-inj-snd : ∀ {a b} {A : Set a} {B : A → Set b} {x : A} {y y₁ : B x} �
                _≡_ {A = Σ A B} (x , y) (x , y₁) → y ≡ y₁
 sigma-inj-snd refl = refl
 
+pair-inj-fst : ∀ {a b} {A : Set a} {B : Set b} {x x₁ : A} {y y₁ : B} →
+               _≡_ {A = A × B} (x , y) (x₁ , y₁) → x ≡ x₁
+pair-inj-fst = sigma-inj-fst
+
+pair-inj-snd : ∀ {a b} {A : Set a} {B : Set b} {x x₁ : A} {y y₁ : B} →
+               _≡_ {A = A × B} (x , y) (x₁ , y₁) → y ≡ y₁
+pair-inj-snd refl = refl
+
 instance
   EqSigma : ∀ {a b} {A : Set a} {B : A → Set b} {{EqA : Eq A}} {{EqB : ∀ {x} → Eq (B x)}} → Eq (Σ A B)
   _==_ {{EqSigma}} (x , y) (x₁ , y₁) with x == x₁

--- a/src/Tactic/Deriving.agda
+++ b/src/Tactic/Deriving.agda
@@ -17,11 +17,11 @@ private
 
   computeTel : Name → Nat → List (Arg Nat) → Telescope → Telescope → Telescope × List (Arg Term)
   computeTel d n xs is [] = reverse is , makeArgs (n + length is) xs
-  computeTel d n xs is (a ∷ tel) =
-    first (hArg (unArg a) ∷_) $
+  computeTel d n xs is ((x , a) ∷ tel) =
+    first ((x , hArg (unArg a)) ∷_) $
     case computeInstanceType d 0 [] (weaken 1 $ unArg a) of λ
     { (just i) → computeTel d (1 + n) ((n <$ a) ∷ xs)
-                              (iArg (weaken (length is) i) ∷ weaken 1 is) tel
+                              ((x , iArg (weaken (length is) i)) ∷ weaken 1 is) tel
     ; nothing  → computeTel d (1 + n) ((n <$ a) ∷ xs) (weaken 1 is) tel }
 
 -- Computes the telescope of instances for a given datatype and class. For instance,

--- a/src/Tactic/Reflection/Free.agda
+++ b/src/Tactic/Reflection/Free.agda
@@ -62,8 +62,8 @@ private
   freeClauses n [] = ∅
   freeClauses n (c ∷ cs) = freeClause n c ∪ freeClauses n cs
 
-  freeClause n (clause ps b)     = freeTerm (patternBindings ps + n) b
-  freeClause n (absurd-clause _) = ∅
+  freeClause n (clause tel ps b)     = freeTerm (length tel + n) b
+  freeClause n (absurd-clause tel _) = ∅
 
 instance
   FreeTerm : FreeVars Term

--- a/src/Tactic/Reflection/Meta.agda
+++ b/src/Tactic/Reflection/Meta.agda
@@ -14,9 +14,13 @@ noMetaArgs : List (Arg Term) → TC ⊤
 noMetaArgs [] = pure _
 noMetaArgs (v ∷ vs) = noMetaArg v *> noMetaArgs vs
 
+noMetaTel : List (String × Arg Type) → TC ⊤
+noMetaTel [] = pure _
+noMetaTel ((x , arg _ a) ∷ tel) = ensureNoMetas a *> noMetaTel tel
+
 noMetaClause : Clause → TC ⊤
-noMetaClause (clause ps t) = ensureNoMetas t
-noMetaClause (absurd-clause ps) = pure _
+noMetaClause (clause tel ps t) = noMetaTel tel *> ensureNoMetas t
+noMetaClause (absurd-clause tel ps) = pure _
 
 noMetaClauses : List Clause → TC ⊤
 noMetaClauses [] = pure _

--- a/src/Tactic/Reflection/Quote.agda
+++ b/src/Tactic/Reflection/Quote.agda
@@ -65,7 +65,7 @@ private
   deriveQuotableTermTypes : Vec Name _ → TC ⊤
   deriveQuotableTermTypes is = do
     let ts : Vec Name _
-        ts = quote Term ∷ quote Clause ∷ quote Sort ∷ []
+        ts = quote Pattern ∷ quote Term ∷ quote Clause ∷ quote Sort ∷ []
         its = ⦇ is , ts ⦈
     traverse (uncurry declareQuotableInstance) its
     traverse (uncurry defineQuotableInstance)  its
@@ -82,8 +82,7 @@ unquoteDecl QuotableVisibility QuotableRelevance QuotableArgInfo
 
 {-# TERMINATING #-}
 unquoteDecl QuotablePattern QuotableTerm QuotableClause QuotableSort = do
-  deriveQuotable QuotablePattern (quote Pattern)
-  deriveQuotableTermTypes (QuotableTerm ∷ QuotableClause ∷ QuotableSort ∷ [])
+  deriveQuotableTermTypes (QuotablePattern ∷ QuotableTerm ∷ QuotableClause ∷ QuotableSort ∷ [])
 
 quoteList : List Term → Term
 quoteList = foldr (λ x xs → con (quote List._∷_) (vArg x ∷ vArg xs ∷ [])) (con (quote List.[]) [])

--- a/src/Tactic/Reflection/Replace.agda
+++ b/src/Tactic/Reflection/Replace.agda
@@ -28,8 +28,8 @@ module Tactic.Reflection.Replace where
       where
 
       replaceClause : Term → Term → Clause → Clause
-      replaceClause l r (clause pats x) = clause pats $ x r[ r / l ]
-      replaceClause l r (absurd-clause pats) = absurd-clause pats
+      replaceClause l r (clause tel pats x) = clause tel pats $ x r[ r / l ]
+      replaceClause l r (absurd-clause tel pats) = absurd-clause tel pats
 
       replaceSort : Term → Term → Sort → Sort
       replaceSort l r (set t) = set $ t r[ r / l ]

--- a/src/Tactic/Reflection/Substitute.agda
+++ b/src/Tactic/Reflection/Substitute.agda
@@ -5,19 +5,6 @@ open import Prelude hiding (abs)
 open import Builtin.Reflection
 open import Tactic.Reflection.DeBruijn
 
-patternArgsVars : List (Arg Pattern) → Nat
-
-patternVars : Pattern → Nat
-patternVars (con _ ps) = patternArgsVars ps
-patternVars dot = 0
-patternVars (var _) = 1
-patternVars (lit x) = 0
-patternVars (proj _) = 0
-patternVars absurd = 0
-
-patternArgsVars [] = 0
-patternArgsVars (arg _ p ∷ ps) = patternVars p + patternArgsVars ps
-
 IsSafe : Term → Set
 IsSafe (lam _ _) = ⊥
 IsSafe _ = ⊤
@@ -95,12 +82,12 @@ substSort σ unknown = unknown
 substClauses σ [] = []
 substClauses σ (c ∷ cs) = substClause σ c ∷ substClauses σ cs
 
-substClause σ (clause ps b) =
-  case patternArgsVars ps of λ
-  { zero    → clause ps (substTerm σ b)
-  ; (suc n) → clause ps (substTerm (reverse (map (λ i → safe (var i []) _) (from 0 to n)) ++ weaken (suc n) σ) b)
+substClause σ (clause tel ps b) =
+  case length tel of λ
+  { zero    → clause tel ps (substTerm σ b)
+  ; (suc n) → clause tel ps (substTerm (reverse (map (λ i → safe (var i []) _) (from 0 to n)) ++ weaken (suc n) σ) b)
   }
-substClause σ (absurd-clause ps) = absurd-clause ps
+substClause σ (absurd-clause tel ps) = absurd-clause tel ps
 
 substArgs σ [] = []
 substArgs σ (x ∷ args) = substArg σ x ∷ substArgs σ args

--- a/src/Tactic/Reflection/Telescope.agda
+++ b/src/Tactic/Reflection/Telescope.agda
@@ -5,17 +5,17 @@ open import Prelude hiding (abs)
 open import Builtin.Reflection
 open import Tactic.Reflection.DeBruijn
 
-Telescope = List (Arg Type)
+Telescope = List (String × Arg Type)
 
 telView : Type → Telescope × Type
-telView (pi a (abs _ b)) = first (_∷_ a) (telView b)
+telView (pi a (abs x b)) = first (_∷_ (x , a)) (telView b)
 telView a                = [] , a
 
 visibleArity : Type → Nat
-visibleArity = length ∘ filter isVisible ∘ fst ∘ telView
+visibleArity = length ∘ filter (isVisible ∘ snd) ∘ fst ∘ telView
 
 telPi : Telescope → Type → Type
-telPi tel b = foldr (λ a b → pi a (abs "_" b)) b tel
+telPi tel b = foldr (λ (x , a) b → pi a (abs x b)) b tel
 
 arity : Name → TC Nat
 arity f = length ∘ fst ∘ telView <$> getType f
@@ -24,7 +24,8 @@ argTel : Name → TC Telescope
 argTel f = fst ∘ telView <$> getType f
 
 telePat : Telescope → List (Arg Pattern)
-telePat = map (var "_" <$_)
+telePat tel = zipWith (λ x (_ , a) → var x <$ a) (reverse $ from 0 for n) tel
+  where n = length tel
 
 private
   teleArgs′ : Nat → List (Arg Type) → List (Arg Term)
@@ -32,7 +33,7 @@ private
   teleArgs′ _ _ = []
 
 teleArgs : Telescope → List (Arg Term)
-teleArgs Γ = teleArgs′ (length Γ) Γ
+teleArgs Γ = teleArgs′ (length Γ) (map snd Γ)
 
 conParams : Name → TC Nat
 conParams c =


### PR DESCRIPTION
I was asked today if Agda has the equivalent of Coq's `@f` syntax for making all arguments to `f` explicit, so I wrote a small macro to do just that. Maybe other people will find it useful as well.