### PR TITLE
Added second level varaible to Acc

### DIFF
--- a/src/Control/WellFounded.agda
+++ b/src/Control/WellFounded.agda
@@ -1,10 +1,9 @@
-
 module Control.WellFounded where
 
 open import Prelude
 open import Prelude.Nat.Properties using (suc-inj)
 
-data Acc {a} {A : Set a} (_<_ : A → A → Set a) (x : A) : Set a where
+data Acc {a b} {A : Set a} (_<_ : A → A → Set b) (x : A) : Set (a ⊔ b) where
   acc : (∀ y → y < x → Acc _<_ y) → Acc _<_ x
 
 -- LessNat is well-founded --


### PR DESCRIPTION
Without another level variable Acc can't be used in some cases. 
It will for example not accept the following:

```
data Acc' {a} {A : Set a} (_<_ : A → A → Set a) (x : A) : Set (a) where
   acc' : (∀ y → y < x → Acc' _<_ y) → Acc' _<_ x

ListSizeCompare : {A : Set ℓ} →  List A → List A → Set
ListSizeCompare a b = length a < length b

mergeSortBy :
  {A : Set ℓ}
  → (A → A → Bool)
  → (l : List A)
  → {(Acc' ListSizeCompare l) }
  → List A
```