### PR TITLE
Add Sized typclass and simple instances

### DIFF
--- a/src/Prelude/List.agda
+++ b/src/Prelude/List.agda
@@ -1,4 +1,3 @@
-
 module Prelude.List where
 
 open import Prelude.Nat
@@ -15,6 +14,8 @@ open import Prelude.Equality
 open import Prelude.Ord
 open import Prelude.Semiring
 open import Prelude.Strict
+
+open import Prelude.Sized
 
 open import Agda.Builtin.List public
 
@@ -243,6 +244,9 @@ instance
 --- Functor ---
 
 instance
+  SizedList : Sized (List A)
+  size {{SizedList}} = length
+
   FunctorList : ∀ {a} → Functor (List {a})
   fmap {{FunctorList}} = map
 

--- a/src/Prelude/Sized.agda
+++ b/src/Prelude/Sized.agda
@@ -1,0 +1,16 @@
+module Prelude.Sized where
+
+open import Prelude.Function
+open import Prelude.Nat
+open import Prelude.Variables
+
+-- A typeclass for everything that has a "Natural size".
+-- Ment to simplify code, not to be theoretical.
+record Sized {a} (A : Set a) : Set a where
+  field
+    size : A → Nat
+open Sized {{...}}
+
+instance
+  SizedNat : Sized Nat
+  size {{SizedNat}} = id


### PR DESCRIPTION
I believe it is a good idea to have a generalized `size` function that gets some (intuitive) size of objects. The main purpose is to minimize name collisions and/or potential naming overhead. 
