### PR TITLE
[ update ] Make `agda-prelude` compatible with `agda/agda#5716`

### DIFF
--- a/src/Tactic/Monoid/Reflect.agda
+++ b/src/Tactic/Monoid/Reflect.agda
@@ -45,8 +45,8 @@ private
   match<> {A = A} dict = do
     `A    ← quoteTC A
     `plus ← quoteTC (Semigroup._<>_ (Monoid.super dict))
-    extendContext (vArg `A) $
-      extendContext (vArg $ weaken 1 `A) $
+    extendContext "x" (vArg `A) $
+      extendContext "x" (vArg $ weaken 1 `A) $
       match 2 <$> normalise (safeApply (weaken 2 `plus) (vArg (safe (var 0 []) _) ∷
                                                          vArg (safe (var 1 []) _) ∷ []))
 

--- a/src/Tactic/Nat/Coprime.agda
+++ b/src/Tactic/Nat/Coprime.agda
@@ -48,7 +48,7 @@ macro
     goal ← inferType ?hole
     ensureNoMetas goal
     cxt  ← reverse <$> getContext
-    (_ , Hyps , Q) , ρ ← runParse (parseProblem (map unArg cxt) goal)
+    (_ , Hyps , Q) , ρ ← runParse (parseProblem (map (unArg ∘ snd) cxt) goal)
     unify ?hole (def (quote proof) $ map vArg (` Q ∷ quotedEnv ρ ∷ Hyps))
       <|> do
         case Q of λ where

--- a/src/Tactic/Nat/Generic.agda
+++ b/src/Tactic/Nat/Generic.agda
@@ -62,8 +62,8 @@ macro
             _        → typeErrorS "Induction tactic must be applied to a function goal"
     let P = lam visible b
         inStepCxt : {A : Set} → TC A → TC A
-        inStepCxt {_} = λ′ (vArg (quoteTerm Nat)) ∘
-                        λ′ (vArg unknown)
+        inStepCxt {_} = λ′ "n" (vArg (quoteTerm Nat)) ∘
+                        λ′ "x" (vArg unknown)
     base ← unknown :′ unknown
     step ← inStepCxt $ unknown :′ unknown
     hole =′ 0→a goal `∘ def₃ (quote nat-induction)

--- a/src/Tactic/Reflection.agda
+++ b/src/Tactic/Reflection.agda
@@ -55,7 +55,7 @@ _`$_ = def₂ (quote _$_)
 _:′_ : Term → Type → TC Term
 _:′_ = checkType
 
-λ′ : ∀ {a} {A : Set a} → Arg Type → TC A → TC A
+λ′ : ∀ {a} {A : Set a} → String → Arg Type → TC A → TC A
 λ′ = extendContext
 
 infix 2 _=′_

--- a/src/Tactic/Reflection/Reright.agda
+++ b/src/Tactic/Reflection/Reright.agda
@@ -245,7 +245,7 @@ module Tactic.Reflection.Reright where
       L≡R-matched ← maybe (typeError (strErr "not an equality" ∷ termErr l≡r ∷ termErr L≡R ∷ [])) pure $
         match 3 (def (quote _≡_) (hArg unknown ∷ (hArg (var₀ 0)) ∷ (vArg (var₀ 1)) ∷ (vArg (var₀ 2)) ∷ [])) L≡R
       𝐺 ← inferGoal hole
-      Γᶜ ← getContext
+      Γᶜ ← map snd <$> getContext
       case L≡R-matched of λ { (A ∷ L ∷ R ∷ []) →
         pure $ record { l≡r = l≡r ; A = A ; L = L ; R = R ; Γᶜ = Γᶜ ; 𝐺 = 𝐺 } }
 

--- a/src/Tactic/Reflection/Telescope.agda
+++ b/src/Tactic/Reflection/Telescope.agda
@@ -5,8 +5,6 @@ open import Prelude hiding (abs)
 open import Builtin.Reflection
 open import Tactic.Reflection.DeBruijn
 
-Telescope = List (String × Arg Type)
-
 telView : Type → Telescope × Type
 telView (pi a (abs x b)) = first (_∷_ (x , a)) (telView b)
 telView a                = [] , a


### PR DESCRIPTION
This PR is to make `cubical` compatible with the recent PR https://github.com/agda/agda/pull/5716, since `extendContext` takes an extra variable of type `String` in the reflection API.

Note that this PR should not be merged unless https://github.com/agda/agda/pull/5716 is merged. 